### PR TITLE
Fix OpenAI client import in retrieval service

### DIFF
--- a/backend/services/retrieval.js
+++ b/backend/services/retrieval.js
@@ -1,4 +1,4 @@
-const { openai } = require('../utils/openaiClient.js');
+const openai = require('../utils/openaiClient.js');
 const { supabase } = require('../utils/supabaseClient.js');
 
 /**


### PR DESCRIPTION
## Summary
- fix retrieval service to import OpenAI client directly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c66e7c79dc832ba32cedb43e8141da