### PR TITLE
Add regex helper utilities and tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -68,3 +68,8 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Regex utilities
+
+The `utils/regexes.js` module provides helper regexes and functions such as
+`findHeadings` and `findCitations` which assist in chunking legal documents.

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
   "description": "This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/backend/utils/regexes.js
+++ b/backend/utils/regexes.js
@@ -43,6 +43,29 @@ const publicReports = {
   procurement: /\b(?:marché[s]? public[s]?|procurement|tender|contrat[s]?)\b/i
 };
 
+// Generic regex helpers
+const articleMarkerRegex = /\b((?:article|art\.?|section|sec\.?)\s*)(\d+[A-Za-z0-9\-]*)/gi;
+
+// Splits an article into subsections when a new paragraph/alinéa marker appears
+// Matches newlines that are immediately followed by an enumeration marker
+const alineaMarkerRegex = /\n(?=\s*(?:\d+|[IVX]+|[A-Z])(?:[.)°-]))/g;
+
+function findHeadings(text) {
+  if (!text) return [];
+  const regex = /^(?:[IVX]+|[A-Z]|\d+)(?:[.)])?\s+[^\n]+/gm;
+  return [...text.match(regex) || []].map(h => h.trim());
+}
+
+function findCitations(text) {
+  if (!text) return [];
+  const citationRegexes = [
+    /\b(?:article|art\.?|section|sec\.?|alinéa|al\.?|para\.?|§|s\.)\s*\d+[A-Za-z0-9\-]*\b/gi,
+    /\b\d{4}\s+[A-Z]{2,}\s+\d+\b/g, // neutral citations
+    /\b[A-Z][A-Za-z0-9]+\s+v(?:s\.?|\.)\s+[A-Z][A-Za-z0-9]+/g
+  ];
+  return citationRegexes.flatMap(r => text.match(r) || []);
+}
+
 // Helpers
 function normalizeNumber(input) {
   if (typeof input === 'number') return input;
@@ -65,6 +88,10 @@ module.exports = {
   judgments,
   doctrine,
   publicReports,
+  articleMarkerRegex,
+  alineaMarkerRegex,
+  findHeadings,
+  findCitations,
   normalizeNumber,
   normalizeCurrencyAmount
 };

--- a/backend/utils/regexes.test.js
+++ b/backend/utils/regexes.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  findHeadings,
+  findCitations,
+  articleMarkerRegex,
+  alineaMarkerRegex
+} = require('./regexes');
+
+test('findHeadings extracts headings', () => {
+  const text = '1. Introduction\nSome text\nI. Background\nA) Subsection';
+  assert.deepStrictEqual(findHeadings(text), [
+    '1. Introduction',
+    'I. Background',
+    'A) Subsection'
+  ]);
+});
+
+test('findCitations finds statute and case references', () => {
+  const text = 'See Article 12 and 2020 SCC 10 in Roe v. Wade.';
+  const citations = findCitations(text);
+  assert.ok(citations.includes('Article 12'));
+  assert.ok(citations.includes('2020 SCC 10'));
+  assert.ok(citations.some(c => /Roe v\. Wade/.test(c)));
+});
+
+test('articleMarkerRegex captures article numbers', () => {
+  const text = 'Article 42\nArticle 5-1';
+  const numbers = [...text.matchAll(articleMarkerRegex)].map(m => m[2]);
+  assert.deepStrictEqual(numbers, ['42', '5-1']);
+});
+
+test('alineaMarkerRegex splits on paragraph markers', () => {
+  const article = 'Intro\n1. First part\n2. Second part';
+  const parts = article.split(alineaMarkerRegex).map(s => s.trim()).filter(Boolean);
+  assert.deepStrictEqual(parts, ['Intro', '1. First part', '2. Second part']);
+});


### PR DESCRIPTION
## Summary
- implement `findHeadings` and `findCitations` helpers
- add `articleMarkerRegex` and `alineaMarkerRegex` with exports
- set up Node test runner with unit tests for regex utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6738f18e0832b9a60cec5c2bded6b