### PR TITLE
Validate uploaded PDFs before parsing

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -23,6 +23,15 @@ router.post('/upload', upload.single('file'), async (req, res) => {
 
   try {
     const dataBuffer = fs.readFileSync(file.path);
+    const hasPDFHeader = dataBuffer.slice(0, 4).toString() === '%PDF';
+    const isPDFMime = file.mimetype === 'application/pdf';
+    if (!hasPDFHeader || !isPDFMime) {
+      fs.unlinkSync(file.path);
+      return res
+        .status(400)
+        .json({ error: 'Invalid or corrupted PDF file' });
+    }
+
     const parsedData = await extractTextWithHelpers(dataBuffer);
     const headerSample = parsedData.text.slice(0, 200);
 


### PR DESCRIPTION
## Summary
- ensure uploaded files are PDFs by checking the file header and MIME type
- abort parsing with a 400 error when an invalid or corrupted PDF is detected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c675686b68832b8e374ecb1443d6e3