### PR TITLE
Handle invalid PDF structure in PDF parsing

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -156,6 +156,10 @@ router.post('/upload', upload.single('file'), async (req, res) => {
     });
 
   } catch (err) {
+    if (err.message === 'Invalid PDF structure') {
+      console.error('❌ PDF parse error: Invalid PDF structure');
+      return res.status(400).json({ error: 'Invalid PDF structure' });
+    }
     console.error('❌ PDF parse error:', err);
     res.status(500).json({ error: 'Failed to parse and embed PDF' });
   }


### PR DESCRIPTION
## Summary
- Wrap `pdfParse` in `extractTextWithHelpers` with error handling for malformed PDFs
- Surface `Invalid PDF structure` errors from `/upload` route with a clear response

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c675d130d8832b88ad129939fad361