### PR TITLE
test: add pdf parsing regression tests

### DIFF
--- a/backend/utils/pdfHelpers.js
+++ b/backend/utils/pdfHelpers.js
@@ -79,7 +79,8 @@ async function extractTextWithHelpers(buffer) {
   } catch (err) {
     if (
       err?.message?.includes('FormatError') ||
-      err?.name?.includes('FormatError')
+      err?.name?.includes('FormatError') ||
+      err?.details?.includes?.('FormatError')
     ) {
       throw new Error('Invalid PDF structure');
     }

--- a/backend/utils/pdfHelpers.test.js
+++ b/backend/utils/pdfHelpers.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { extractTextWithHelpers } = require('./pdfHelpers');
+
+const pdfModulePath = path.dirname(require.resolve('pdf-parse/package.json'));
+const validPdf = path.join(pdfModulePath, 'test', 'data', '04-valid.pdf');
+const invalidPdf = path.join(pdfModulePath, 'test', 'data', '03-invalid.pdf');
+
+test('extractTextWithHelpers parses PDF text', async () => {
+  const buffer = fs.readFileSync(validPdf);
+  const result = await extractTextWithHelpers(buffer);
+  assert.ok(
+    result.text.includes('Turk J Med Sci'),
+    'Expected text not found in parsed PDF'
+  );
+});
+
+test('extractTextWithHelpers rejects invalid PDFs', async () => {
+  const buffer = fs.readFileSync(invalidPdf);
+  await assert.rejects(
+    () => extractTextWithHelpers(buffer),
+    /Invalid PDF structure/
+  );
+});


### PR DESCRIPTION
## Summary
- add regression tests for pdf parsing to verify valid and invalid documents
- expand pdf error handling to recognize FormatError details
- load pdf fixtures from pdf-parse package to avoid repository binary files

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c676590370832bb724684f5b29a10a