### PR TITLE
Add self-test to regexes utility module

### DIFF
--- a/backend/utils/regexes.js
+++ b/backend/utils/regexes.js
@@ -95,3 +95,7 @@ module.exports = {
   normalizeNumber,
   normalizeCurrencyAmount
 };
+
+if (require.main === module) {
+  console.log('Available exports:', Object.keys(module.exports));
+}


### PR DESCRIPTION
## Summary
- add runtime self-test that logs available exports for `regexes.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67ada2cd4832b84ff6f57ca37ded6