### PR TITLE
Add test for cutStatute calling findHeadings

### DIFF
--- a/backend/services/chunkings.test.js
+++ b/backend/services/chunkings.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+test('cutStatute invokes findHeadings without throwing', t => {
+  const regexes = require('../utils/regexes');
+  const spy = t.mock.method(regexes, 'findHeadings');
+
+  const { cutStatute } = require('./chunkings');
+
+  const sampleText = 'Article 1\nSome content\nArticle 2\nMore content';
+  const meta = { doc_id: 'doc1', type: 'statute' };
+
+  assert.doesNotThrow(() => {
+    cutStatute(sampleText, meta);
+  });
+
+  assert.ok(spy.mock.calls.length > 0);
+});
+


### PR DESCRIPTION
## Summary
- add unit test ensuring cutStatute invokes findHeadings when processing statute text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67ad1cff0832bb3c14f745ae47960