### PR TITLE
Validate PDF uploads before parsing

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -23,9 +23,10 @@ router.post('/upload', upload.single('file'), async (req, res) => {
 
   try {
     const dataBuffer = fs.readFileSync(file.path);
-    const hasPDFHeader = dataBuffer.slice(0, 4).toString() === '%PDF';
-    const isPDFMime = file.mimetype === 'application/pdf';
-    if (!hasPDFHeader || !isPDFMime) {
+    if (
+      file.mimetype !== 'application/pdf' ||
+      dataBuffer.slice(0, 4).toString() !== '%PDF'
+    ) {
       fs.unlinkSync(file.path);
       return res
         .status(400)


### PR DESCRIPTION
## Summary
- Ensure upload route validates PDF MIME type and header before parsing

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c68027187c832b8248d95888425c38