### PR TITLE
feat: replace alert with toast in chat

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
+        "react-toastify": "^11.0.5",
         "web-vitals": "^2.1.4",
         "zustand": "^5.0.5"
       }
@@ -6092,6 +6093,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -15751,6 +15761,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
+    "react-toastify": "^11.0.5",
     "web-vitals": "^2.1.4",
     "zustand": "^5.0.5"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { useResizable } from './hooks/useResizable';
 import Sidebar from './components/Sidebar';
 import RightPanel from './components/RightPanel';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 const App = () => {
   const [documents, setDocuments] = useState([]);
@@ -47,6 +49,7 @@ const App = () => {
       <div className="panel right-panel-main">
         <RightPanel selectedDoc={selectedDoc} />
       </div>
+      <ToastContainer />
     </div>
   );
 };

--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import ChatMessage from './ChatMessage';
 import { api } from '../../utils/api';
 import ChatHistory from './ChatHistory';
+import { toast } from 'react-toastify';
 
 // Icones 
 import com003 from '../../icons/com/com003.svg' ;
@@ -25,7 +26,7 @@ const ChatBox = ({ selectedDoc }) => {
     if (!input.trim()) return;
 
     if (!selectedDoc) {
-      alert('Please select a document first');
+      toast.error('Please select a document first');
       return;
     }
 
@@ -138,7 +139,7 @@ const ChatBox = ({ selectedDoc }) => {
           />
           <button 
             onClick={handleSend}
-            disabled={!input.trim() || !selectedDoc || loading}
+            disabled={!selectedDoc || !input.trim() || loading}
             className="send-button"
           >
             {loading ? '⏳' : '🚀'}


### PR DESCRIPTION
## Summary
- replace alert in ChatBox with react-toastify toast
- ensure send button disabled when no document selected
- add ToastContainer to App and react-toastify dependency

## Testing
- `npm test -- --watchAll=false` (fails: Jest encountered an unexpected token in react-markdown)


------
https://chatgpt.com/codex/tasks/task_e_68c6844b8dc4832b9f17f98cbaf255e0