### PR TITLE
Use toastify warnings for chat and add toast container

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -49,7 +49,7 @@ const App = () => {
       <div className="panel right-panel-main">
         <RightPanel selectedDoc={selectedDoc} />
       </div>
-      <ToastContainer />
+      <ToastContainer position="bottom-right" />
     </div>
   );
 };

--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -26,7 +26,7 @@ const ChatBox = ({ selectedDoc }) => {
     if (!input.trim()) return;
 
     if (!selectedDoc) {
-      toast.error('Please select a document first');
+      toast.warn('Please select a document first');
       return;
     }
 
@@ -137,9 +137,9 @@ const ChatBox = ({ selectedDoc }) => {
             rows={1}
             className="chat-input"
           />
-          <button 
+          <button
             onClick={handleSend}
-            disabled={!selectedDoc || !input.trim() || loading}
+            disabled={!input.trim() || !selectedDoc || loading}
             className="send-button"
           >
             {loading ? '⏳' : '🚀'}


### PR DESCRIPTION
## Summary
- use `toast.warn` when no document is selected in chat
- keep send button disabled without input, selected doc, or while loading
- render a bottom-right `ToastContainer` and import toastify styles

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token in `react-markdown`)*

------
https://chatgpt.com/codex/tasks/task_e_68c686c5a3d4832bbf1e5e493c865a3c