### PR TITLE
fix: use session_id key in chat payload

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -53,9 +53,9 @@ export const api = {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        message: message  ,
+        message: message,
         document_ids: documentIds, // Your backend expects this format
-        sessionid : "12122212"
+        session_id: "12122212",
       }),
     });
     


### PR DESCRIPTION
## Summary
- use `session_id` key in `sendMessage` API payload to match backend expectations

## Testing
- `cd frontend && CI=true npm test` (fails: Jest encountered an unexpected token)


------
https://chatgpt.com/codex/tasks/task_e_68c690fb73d4832b96c2b9a796f952c5