### PR TITLE
Default chat retrieval to document_segments

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -73,3 +73,8 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/t
 
 The `utils/regexes.js` module provides helper regexes and functions such as
 `findHeadings` and `findCitations` which assist in chunking legal documents.
+
+### Environment variables
+
+The chat endpoint retrieves context from the `document_segments` table by default.
+Set `RAG_V2=0` to fall back to the legacy `chunks`-based retrieval.

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -56,13 +56,15 @@ Si aucune source n'est fournie, indiquez-le clairement. Ne devinez jamais et n'i
 
     let messages = [];
 
-    if (process.env.RAG_V2 === '1') {
-      const segments = await retrieveByQuery({
+    // Par défaut, on interroge les "document_segments". 
+    // Définir RAG_V2=0 pour utiliser l'ancien mode basé sur "chunks".
+    if (process.env.RAG_V2 !== '0') {
+      const { segments } = await retrieveByQuery({
         query: message,
         filters: req.body?.filters || {}
       });
       const contextText = segments
-        .map(seg => `[${seg.metadata.type}:${seg.metadata.role}] ${seg.text}`)
+        .map(seg => `[${seg.type}:${seg.role}] ${seg.text}`)
         .join('\n\n');
       const citationIds = segments.map(seg => seg.id).join(', ');
 


### PR DESCRIPTION
## Summary
- Default chat endpoint to use `document_segments` retrieval unless `RAG_V2=0`
- Document `RAG_V2` environment variable and new default behaviour

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6911c2f24832b8e095b21310e3c52