### PR TITLE
Expose detailed PDF structure parse errors

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -39,8 +39,10 @@ router.post('/upload', upload.single('file'), async (req, res) => {
     } catch (err) {
       fs.unlinkSync(file.path);
       if (err.message === 'Invalid PDF structure') {
-        console.error('❌ PDF parse error: Invalid PDF structure');
-        return res.status(400).json({ error: 'Invalid PDF structure' });
+        console.error('❌ PDF parse error:', err.message);
+        return res
+          .status(400)
+          .json({ error: `Invalid PDF structure: ${err.message}` });
       }
       console.error('❌ PDF parse error:', err);
       return res.status(500).json({ error: 'Failed to parse and embed PDF' });


### PR DESCRIPTION
## Summary
- include original parse error message when PDF has an invalid structure
- respond with explicit error text so users can diagnose corrupt PDFs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c693655468832b8f97b9106fc6f50b