### PR TITLE
Handle both snake_case and camelCase document IDs

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -17,7 +17,7 @@ function cosineSimilarity(a, b) {
 
 router.post('/chat', async (req, res) => {
   const { message, session_id, vulgarisation = false } = req.body;
-  let document_ids = req.body.document_ids;
+  let document_ids = req.body.document_ids || req.body.documentIds || [];
   const startTime = Date.now();
 
   try {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -53,8 +53,9 @@ export const api = {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        message: message,
-        document_ids: documentIds, // Your backend expects this format
+        message,
+        document_ids: documentIds, // Backend expects snake_case
+        documentIds, // Also send camelCase for compatibility
         session_id: "12122212",
       }),
     });


### PR DESCRIPTION
## Summary
- Send both `document_ids` and `documentIds` in frontend chat requests
- Accept either `document_ids` or `documentIds` in backend `/chat` route

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend) *(fails: Jest encountered an unexpected token)*
- `npm run build` (frontend) *(fails: Module not found: Can't resolve 'react-toastify/dist/ReactToastify.css')*

------
https://chatgpt.com/codex/tasks/task_e_68c696a75788832bb214440277a751de