### PR TITLE
Limit RAG retrieval to selected documents

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -56,12 +56,12 @@ Si aucune source n'est fournie, indiquez-le clairement. Ne devinez jamais et n'i
 
     let messages = [];
 
-    // Par défaut, on interroge les "document_segments". 
+    // Par défaut, on interroge les "document_segments".
     // Définir RAG_V2=0 pour utiliser l'ancien mode basé sur "chunks".
     if (process.env.RAG_V2 !== '0') {
       const { segments } = await retrieveByQuery({
         query: message,
-        filters: req.body?.filters || {}
+        filters: { ...(req.body?.filters || {}), doc_id: document_ids }
       });
       const contextText = segments
         .map(seg => `[${seg.type}:${seg.role}] ${seg.text}`)


### PR DESCRIPTION
## Summary
- Restrict RAG v2 retrieval to specific documents by passing `doc_id` filter to `retrieveByQuery`

## Testing
- `npm test`
- `npm start` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c69d1fc510832bac6b2b3b19c95f57