### PR TITLE
Unify document segment identifier

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -61,7 +61,7 @@ Si aucune source n'est fournie, indiquez-le clairement. Ne devinez jamais et n'i
     if (process.env.RAG_V2 !== '0') {
       const { segments } = await retrieveByQuery({
         query: message,
-        filters: { ...(req.body?.filters || {}), doc_id: document_ids }
+        filters: { ...(req.body?.filters || {}), document_id: document_ids }
       });
       const contextText = segments
         .map(seg => `[${seg.type}:${seg.role}] ${seg.text}`)

--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -122,7 +122,7 @@ router.post('/upload', upload.single('file'), async (req, res) => {
     } = await chunkingsPromise;
     const { embedAndStoreSegments } = await embeddingPromise;
 
-    const meta = { doc_id: docInsert.id, type: family };
+    const meta = { document_id: docInsert.id, type: family };
     let segments = [];
     switch (family) {
       case 'regulation':
@@ -142,8 +142,6 @@ router.post('/upload', upload.single('file'), async (req, res) => {
         segments = cutStatute(parsedData.text, meta);
         break;
     }
-
-    segments = segments.map((s) => ({ ...s, document_id: s.doc_id }));
 
     await embedAndStoreSegments(segments, { supabase });
 

--- a/backend/scripts/ingest-dry-run.js
+++ b/backend/scripts/ingest-dry-run.js
@@ -66,7 +66,7 @@ async function run() {
   const docType = type === 'auto' ? detectType(text) : type;
   console.log(`Document type: ${docType}`);
 
-  const meta = { doc_id: 'dry-run', type: docType };
+  const meta = { document_id: 'dry-run', type: docType };
   const chunkings = await import('../services/chunkings.js');
 
   let segments = [];

--- a/backend/services/chunkings.js
+++ b/backend/services/chunkings.js
@@ -14,7 +14,7 @@ function countTokens(text) {
 
 function createSegment(meta, role, text, extra = {}) {
   return {
-    doc_id: meta.doc_id,
+    document_id: meta.document_id,
     type: meta.type,
     role,
     text: text.trim(),

--- a/backend/services/chunkings.test.js
+++ b/backend/services/chunkings.test.js
@@ -8,7 +8,7 @@ test('cutStatute invokes findHeadings without throwing', t => {
   const { cutStatute } = require('./chunkings');
 
   const sampleText = 'Article 1\nSome content\nArticle 2\nMore content';
-  const meta = { doc_id: 'doc1', type: 'statute' };
+  const meta = { document_id: 'doc1', type: 'statute' };
 
   assert.doesNotThrow(() => {
     cutStatute(sampleText, meta);

--- a/backend/services/retrieval.js
+++ b/backend/services/retrieval.js
@@ -97,7 +97,7 @@ async function expandWithKG(segments, intent) {
     .in('src_segment_id', segIds);
 
   const dstSegIds = edges.map(e => e.dst_segment_key).filter(Boolean);
-  const dstDocIds = edges.map(e => e.dst_doc_key).filter(Boolean);
+  const dstDocumentIds = edges.map(e => e.dst_doc_key).filter(Boolean);
 
   let extra = [];
   if (dstSegIds.length) {
@@ -107,8 +107,8 @@ async function expandWithKG(segments, intent) {
       .in('id', dstSegIds);
     extra = extra.concat(data || []);
   }
-  if (dstDocIds.length) {
-    let qb = supabase.from('document_segments').select('*').in('doc_id', dstDocIds);
+  if (dstDocumentIds.length) {
+    let qb = supabase.from('document_segments').select('*').in('document_id', dstDocumentIds);
     if (intent.roles.length) qb = qb.in('role', intent.roles);
     const { data } = await qb;
     extra = extra.concat(data || []);

--- a/backend/utils/graphBuilder.js
+++ b/backend/utils/graphBuilder.js
@@ -13,7 +13,7 @@ function extractAndBuildEdges(segments = []) {
   const pushEdge = ({ src, rel, dstKey, dstType, dstSegmentKey, payload }) => {
     if (!dstKey) {
       unresolved.push({
-        src_doc_id: src.doc_id,
+        src_doc_id: src.document_id,
         src_segment_id: src.segment_id,
         rel,
         target: dstKey
@@ -22,7 +22,7 @@ function extractAndBuildEdges(segments = []) {
     }
     edges.push({
       id: randomUUID(),
-      src_doc_id: src.doc_id,
+      src_doc_id: src.document_id,
       src_segment_id: src.segment_id,
       src_type: src.type,
       rel,
@@ -34,9 +34,9 @@ function extractAndBuildEdges(segments = []) {
   };
 
   segments.forEach((seg) => {
-    const { doc_id, type, role, metadata = {} } = seg;
+    const { document_id, type, role, metadata = {} } = seg;
     const src = {
-      doc_id,
+      document_id,
       segment_id: metadata.segment_id || metadata.id || null,
       type
     };

--- a/supabase/migrations/20241004120000_rename_doc_id_to_document_id.sql
+++ b/supabase/migrations/20241004120000_rename_doc_id_to_document_id.sql
@@ -1,0 +1,46 @@
+-- Rename doc_id to document_id in document_segments table
+ALTER TABLE document_segments RENAME COLUMN doc_id TO document_id;
+
+-- Update match_document_segments function to use document_id
+CREATE OR REPLACE FUNCTION match_document_segments(
+  query_embedding vector,
+  match_threshold float,
+  match_count int,
+  filter jsonb
+)
+RETURNS TABLE (
+  id uuid,
+  document_id uuid,
+  type text,
+  role text,
+  text text,
+  metadata jsonb,
+  similarity float
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    ds.id,
+    ds.document_id,
+    ds.type,
+    ds.role,
+    ds.text,
+    ds.metadata,
+    1 - (ds.embedding <=> query_embedding) AS similarity
+  FROM document_segments ds
+  WHERE (
+      (filter->>'document_id') IS NULL OR ds.document_id = ANY (SELECT jsonb_array_elements_text(filter->'document_id'))
+    )
+    AND (
+      (filter->>'type') IS NULL OR ds.type = ANY (SELECT jsonb_array_elements_text(filter->'type'))
+    )
+    AND (
+      (filter->>'role') IS NULL OR ds.role = ANY (SELECT jsonb_array_elements_text(filter->'role'))
+    )
+    AND 1 - (ds.embedding <=> query_embedding) > match_threshold
+  ORDER BY ds.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;


### PR DESCRIPTION
## Summary
- standardize `document_segments` to use `document_id` everywhere
- rename metadata and ingestion pipeline to emit `document_id`
- add migration to rename column and update retrieval function

## Testing
- `npm test`
- `node backend/scripts/ingest-dry-run.js --file backend/node_modules/pdf-parse/test/data/01-valid.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68c69d8b2010832bb058f1811fa41448