### PR TITLE
feat: generate chat session identifiers

### DIFF
--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -13,6 +13,7 @@ const ChatBox = ({ selectedDoc }) => {
   const [loading, setLoading] = useState(false);
   const [, setError] = useState(null);
   const messagesEndRef = useRef(null);
+  const sessionIdRef = useRef(crypto.randomUUID());
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -51,7 +52,11 @@ const ChatBox = ({ selectedDoc }) => {
 
     try {
       // Call your real API
-      const response = await api.sendMessage(userMessage, [selectedDoc.id]);
+      const response = await api.sendMessage(
+        userMessage,
+        [selectedDoc.id],
+        sessionIdRef.current
+      );
       
       // Add AI response to chat
       setMessages(prev => [...prev, { 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -46,7 +46,7 @@ export const api = {
   },
 
   // Chat with AI - matches your /api/chat endpoint
-  sendMessage: async (message, documentIds) => {
+  sendMessage: async (message, documentIds, sessionId) => {
     const response = await fetch(`${API_BASE_URL}/api/chat`, {
       method: 'POST',
       headers: {
@@ -56,7 +56,7 @@ export const api = {
         message,
         document_ids: documentIds, // Backend expects snake_case
         documentIds, // Also send camelCase for compatibility
-        session_id: "12122212",
+        session_id: sessionId || crypto.randomUUID(),
       }),
     });
     


### PR DESCRIPTION
## Summary
- accept a session ID in the sendMessage API call and generate one if missing
- generate a session identifier in ChatBox and forward it to API requests

## Testing
- `npm test --silent` (backend)
- `npm test --silent` (frontend) *(fails: SyntaxError from react-markdown ESM)*
- `node backend/testConnection.js` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c69ed355cc832b82c51279492f3977