### PR TITLE
Return 400 when no document selected or indexed

### DIFF
--- a/backend/routes/mindmap.js
+++ b/backend/routes/mindmap.js
@@ -9,15 +9,27 @@ router.post('/mindmap', async (req, res) => {
 
   console.log('🟡 Received document_ids:', document_ids);
 
+  if (!Array.isArray(document_ids) || document_ids.length === 0) {
+    return res
+      .status(400)
+      .json({ error: 'No document selected or document not indexed' });
+  }
+
   try {
     const { data: docs, error: fetchErr } = await supabase
       .from('documents')
       .select('text_content') // change this to match your actual column name
       .in('id', document_ids);
 
-    if (fetchErr || !docs) {
+    if (fetchErr) {
       console.error('❌ Failed to fetch document text:', fetchErr);
       return res.status(500).json({ error: 'Failed to load document text.' });
+    }
+
+    if (!docs || docs.length === 0) {
+      return res
+        .status(400)
+        .json({ error: 'No document selected or document not indexed' });
     }
 
     const fullText = docs.map(doc => doc.text_content).join('\n\n');

--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -67,10 +67,16 @@ const ChatBox = ({ selectedDoc }) => {
     } catch (err) {
       console.error('Chat error:', err);
       setError(err.message);
-      
+
+      let errorMessage = err.message;
+      if (errorMessage === 'No document selected or document not indexed') {
+        errorMessage += '. Please re-select or re-ingest the PDF.';
+        toast.error(errorMessage);
+      }
+
       // Add error message to chat
       setMessages(prev => [...prev, {
-        message: `Sorry, I encountered an error: ${err.message}`,
+        message: errorMessage,
         isUser: false,
         isError: true
       }]);

--- a/frontend/src/components/MindMapView/index.jsx
+++ b/frontend/src/components/MindMapView/index.jsx
@@ -25,7 +25,11 @@ const MindMapView = ({ selectedDoc }) => {
       setMindMap(response.mindmap);
     } catch (err) {
       console.error('MindMap generation error:', err);
-      setError(err.message);
+      let errorMessage = err.message;
+      if (errorMessage === 'No document selected or document not indexed') {
+        errorMessage += '. Please re-select or re-ingest the PDF.';
+      }
+      setError(errorMessage);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Remove backend fallback that loaded all documents and instead return 400 when no document IDs are provided or when no segments/chunks are found
- Surface same 400 error in mindmap route when IDs missing or not indexed
- Show error in chat and mind map UIs prompting user to re-select or re-ingest the PDF

## Testing
- `npm test`
- `CI=true npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f9aded9c832baddd08eaf1fc86d8