### PR TITLE
Preserve paragraph boundaries and extract PDF tables

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -35,7 +35,7 @@ router.post('/upload', upload.single('file'), async (req, res) => {
 
     let parsedData;
     try {
-      parsedData = await extractTextWithHelpers(dataBuffer);
+      parsedData = await extractTextWithHelpers(dataBuffer, path.dirname(file.path));
     } catch (err) {
       fs.unlinkSync(file.path);
       if (err.message === 'Invalid PDF structure') {
@@ -135,7 +135,7 @@ router.post('/upload', upload.single('file'), async (req, res) => {
         segments = cutDoctrine(parsedData.text, meta);
         break;
       case 'public_report':
-        segments = cutPublicReport(parsedData.text, meta);
+        segments = cutPublicReport(parsedData.text, meta, parsedData.tables);
         break;
       case 'statute':
       default:

--- a/backend/scripts/ingest-dry-run.js
+++ b/backend/scripts/ingest-dry-run.js
@@ -60,8 +60,9 @@ async function run() {
     process.exit(1);
   }
 
-  const buffer = fs.readFileSync(path.resolve(file));
-  const { text } = await extractTextWithHelpers(buffer);
+  const resolved = path.resolve(file);
+  const buffer = fs.readFileSync(resolved);
+  const { text, tables } = await extractTextWithHelpers(buffer, path.dirname(resolved));
 
   const docType = type === 'auto' ? detectType(text) : type;
   console.log(`Document type: ${docType}`);
@@ -84,7 +85,7 @@ async function run() {
       segments = chunkings.cutDoctrine(text, meta);
       break;
     case 'public_report':
-      segments = chunkings.cutPublicReport(text, meta);
+      segments = chunkings.cutPublicReport(text, meta, tables);
       break;
     default:
       console.error('❌ Could not detect document type. Use --type to specify.');

--- a/backend/services/chunkings.js
+++ b/backend/services/chunkings.js
@@ -218,7 +218,7 @@ function cutDoctrine(docText, meta) {
   return segments;
 }
 
-function cutPublicReport(docText, meta) {
+function cutPublicReport(docText, meta, tables = []) {
   const roles = [
     'header',
     'executive_summary',
@@ -257,6 +257,16 @@ function cutPublicReport(docText, meta) {
             amounts: extractAmounts(r)
           })
         );
+      });
+    } else if (role === 'annex_caption') {
+      sections[role].forEach(caption => {
+        const table = tables.find(
+          t => t.caption.trim().toLowerCase() === caption.trim().toLowerCase()
+        );
+        const extra = table
+          ? { table_id: table.id, table_csv_url: table.csv_url }
+          : {};
+        segments.push(createSegment(meta, role, caption, extra));
       });
     } else {
       segments.push(

--- a/backend/utils/pdfHelpers.js
+++ b/backend/utils/pdfHelpers.js
@@ -1,4 +1,6 @@
 const pdfParse = require('pdf-parse');
+const fs = require('fs');
+const path = require('path');
 
 function stripHeadersFooters(pages) {
   const headerCounts = new Map();
@@ -51,28 +53,57 @@ function preserveFootnoteAnchors(text) {
   return text.replace(/\s*(\[\d+\]|\(\d+\)|\^\d+)/g, ' $1');
 }
 
-function detectTables(pages) {
-  const tableRegex = /table\s+\d+/i;
+function detectTables(pages, outputDir) {
+  const tableRegex = /^table\s+\d+/i;
   const tables = [];
+  fs.mkdirSync(outputDir, { recursive: true });
+  let idx = 1;
+
   pages.forEach((page) => {
-    page.split(/\n/).forEach((line) => {
+    const lines = page.split(/\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
       if (tableRegex.test(line)) {
-        tables.push({ caption: line.trim(), csv: null });
+        const id = `table-${idx++}`;
+        const caption = line;
+        const rows = [];
+        i++;
+        while (i < lines.length && lines[i].trim() !== '') {
+          rows.push(lines[i]);
+          i++;
+        }
+        let csvPath = null;
+        if (rows.length) {
+          const csv = rows
+            .map((r) =>
+              r
+                .trim()
+                .split(/\s{2,}|\t/)
+                .map((c) => `"${c.replace(/"/g, '""')}"`)
+                .join(',')
+            )
+            .join('\n');
+          const filename = `${id}.csv`;
+          csvPath = path.join(outputDir, filename);
+          fs.writeFileSync(csvPath, csv, 'utf8');
+        }
+        tables.push({ id, caption, csv_url: csvPath });
       }
-    });
+    }
   });
   return tables;
 }
 
-async function extractTextWithHelpers(buffer) {
+async function extractTextWithHelpers(buffer, outputDir = '.') {
   const rawPages = [];
-  let data;
   try {
-    data = await pdfParse(buffer, {
+    await pdfParse(buffer, {
       pagerender: (pageData) =>
         pageData.getTextContent().then((textContent) => {
-          const text = textContent.items.map((item) => item.str).join(' ');
-          rawPages.push(text);
+          const text = textContent.items
+            .map((item) => item.str + (item.hasEOL ? '\n' : ' '))
+            .join('');
+          rawPages.push(text.trim());
           return text;
         }),
     });
@@ -83,12 +114,12 @@ async function extractTextWithHelpers(buffer) {
     throw err;
   }
 
-  let pages = stripHeadersFooters(rawPages).map((p) => mergeHyphenatedWords(p));
+  const pages = stripHeadersFooters(rawPages).map((p) => mergeHyphenatedWords(p));
   let text = pages.join('\n');
   text = preserveFootnoteAnchors(text);
-  const tables = detectTables(pages);
+  const tables = detectTables(pages, outputDir);
 
-  return { ...data, text, tables };
+  return { text, tables };
 }
 
 module.exports = {

--- a/backend/utils/pdfHelpers.test.js
+++ b/backend/utils/pdfHelpers.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 
 const pdfModulePath = path.dirname(require.resolve('pdf-parse/package.json'));
 const validPdf = path.join(pdfModulePath, 'test', 'data', '04-valid.pdf');
@@ -13,11 +14,12 @@ test('extractTextWithHelpers parses PDF text', async () => {
   delete require.cache[pdfHelpersPath];
   const { extractTextWithHelpers } = require(pdfHelpersPath);
   const buffer = fs.readFileSync(validPdf);
-  const result = await extractTextWithHelpers(buffer);
+  const result = await extractTextWithHelpers(buffer, fs.mkdtempSync(path.join(os.tmpdir(), 'pdf-')));
   assert.ok(
     result.text.includes('Turk J Med Sci'),
     'Expected text not found in parsed PDF'
   );
+  assert.ok(Array.isArray(result.tables));
 });
 
 test('extractTextWithHelpers rethrows non-FormatError exceptions', async () => {
@@ -46,4 +48,20 @@ test('extractTextWithHelpers converts FormatError to Invalid PDF structure', asy
   );
   require.cache[pdfParsePath].exports = originalPdfParse;
   delete require.cache[pdfHelpersPath];
+});
+
+test('detectTables extracts tables to CSV', () => {
+  delete require.cache[pdfHelpersPath];
+  const { detectTables } = require(pdfHelpersPath);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tables-'));
+  const pages = [
+    'Table 1: Numbers\nA   B\n1   2\n3   4\n\nEnd',
+  ];
+  const tables = detectTables(pages, tmpDir);
+  assert.strictEqual(tables.length, 1);
+  const table = tables[0];
+  assert.ok(table.id && table.caption.includes('Table 1'));
+  assert.ok(fs.existsSync(table.csv_url));
+  const csv = fs.readFileSync(table.csv_url, 'utf8');
+  assert.ok(csv.replace(/"/g, '').includes('A,B'));
 });


### PR DESCRIPTION
## Summary
- Preserve original paragraph boundaries and collect table metadata when parsing PDFs
- Extract detected tables to CSV files with unique IDs
- Link annex captions to extracted tables in public report chunking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c709a210e0832b9deda8d6aba679ff