### PR TITLE
Normalize public report entities via registry

### DIFF
--- a/backend/services/chunkings.js
+++ b/backend/services/chunkings.js
@@ -6,6 +6,7 @@ const {
   articleMarkerRegex,
   alineaMarkerRegex
 } = require('../utils/regexes.js');
+const { resolveEntities } = require('./nlp/entityRegistry');
 
 function countTokens(text) {
   if (!text) return 0;
@@ -250,18 +251,20 @@ function cutPublicReport(docText, meta) {
     if (role === 'recommendation') {
       const recs = text.split(/\n(?=\s*\d+\.|-)/).filter(r => r.trim());
       recs.forEach(r => {
+        const entitiesMentioned = resolveEntities(extractEntities(r));
         segments.push(
           createSegment(meta, role, r, {
-            entities: extractEntities(r),
+            entities_mentioned: entitiesMentioned,
             irregularities: extractIrregularities(r),
             amounts: extractAmounts(r)
           })
         );
       });
     } else {
+      const entitiesMentioned = resolveEntities(extractEntities(text));
       segments.push(
         createSegment(meta, role, text, {
-          entities: extractEntities(text),
+          entities_mentioned: entitiesMentioned,
           irregularities: extractIrregularities(text),
           amounts: extractAmounts(text)
         })

--- a/backend/services/chunkings.test.js
+++ b/backend/services/chunkings.test.js
@@ -17,3 +17,16 @@ test('cutStatute invokes findHeadings without throwing', t => {
   assert.ok(spy.mock.calls.length > 0);
 });
 
+test('cutPublicReport resolves entities via registry', () => {
+  const { cutPublicReport } = require('./chunkings');
+
+  const sample = 'header\nAcme\nrecommendation\n- Acme was sanctioned.';
+  const meta = { document_id: 'doc2', type: 'public_report' };
+  const segments = cutPublicReport(sample, meta);
+  const recSegment = segments.find(s => s.role === 'recommendation');
+
+  assert.deepStrictEqual(recSegment.metadata.entities_mentioned, [
+    { name: 'ACME Corporation', sector: 'manufacturing' }
+  ]);
+});
+

--- a/backend/services/nlp/entityRegistry.js
+++ b/backend/services/nlp/entityRegistry.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { createClient } = require('@supabase/supabase-js');
+
+// Base in-memory registry of alias -> { name, sector }
+// Keys are stored in lowercase for case-insensitive lookup.
+let registry = {
+  acme: { name: 'ACME Corporation', sector: 'manufacturing' },
+  globex: { name: 'Globex Corporation', sector: 'technology' }
+};
+
+function loadYamlRegistry() {
+  try {
+    const file = path.join(__dirname, 'entityRegistry.yaml');
+    if (!fs.existsSync(file)) return {};
+    const data = yaml.load(fs.readFileSync(file, 'utf8')) || {};
+    const map = {};
+    for (const [alias, info] of Object.entries(data)) {
+      if (info && info.name) {
+        map[alias.toLowerCase()] = {
+          name: info.name,
+          sector: info.sector || null
+        };
+      }
+    }
+    return map;
+  } catch (err) {
+    console.error('Failed to load entity registry from YAML', err);
+    return {};
+  }
+}
+
+async function loadSupabaseRegistry() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_ANON_KEY) return {};
+  try {
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_ANON_KEY
+    );
+    const { data, error } = await supabase
+      .from('entity_registry')
+      .select('alias,name,sector');
+    if (error) throw error;
+    const map = {};
+    for (const row of data) {
+      if (row.alias && row.name) {
+        map[row.alias.toLowerCase()] = {
+          name: row.name,
+          sector: row.sector || null
+        };
+      }
+    }
+    return map;
+  } catch (err) {
+    console.error('Failed to load entity registry from Supabase', err);
+    return {};
+  }
+}
+
+function preloadRegistry() {
+  registry = { ...registry, ...loadYamlRegistry() };
+}
+
+preloadRegistry();
+
+async function preloadFromSupabase() {
+  const data = await loadSupabaseRegistry();
+  registry = { ...registry, ...data };
+}
+
+function resolveEntities(names = []) {
+  const seen = new Set();
+  return names
+    .map(n => n && n.toLowerCase())
+    .filter(Boolean)
+    .map(alias => {
+      const entry = registry[alias];
+      return entry ? entry : { name: alias, sector: null };
+    })
+    .filter(entry => {
+      const key = entry.name.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+module.exports = { resolveEntities, preloadFromSupabase };


### PR DESCRIPTION
## Summary
- add NLP entity registry with alias mapping and optional Supabase/YAML preload
- normalize extracted names in `cutPublicReport` using `resolveEntities`
- test entity normalization in public reports

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c709a37d58832b8a07bf513c734909