### PR TITLE
Add chat filter support to chat interface

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -51,9 +51,10 @@ Si aucune source n'est fournie, indiquez-le clairement. Ne devinez jamais et n'i
     // Par défaut, on interroge les "document_segments".
     // Définir RAG_V2=0 pour utiliser l'ancien mode basé sur "chunks".
     if (process.env.RAG_V2 !== '0') {
+      const bodyFilters = req.body && req.body.filters ? req.body.filters : {};
       const { segments } = await retrieveByQuery({
         query: message,
-        filters: { ...(req.body?.filters || {}), document_id: document_ids }
+        filters: { ...bodyFilters, document_id: document_ids }
       });
 
       if (!segments || segments.length === 0) {

--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -12,6 +12,12 @@ const ChatBox = ({ selectedDoc }) => {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
   const [, setError] = useState(null);
+  // Filters
+  const [entity, setEntity] = useState('');
+  const [irregularities, setIrregularities] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [followUp, setFollowUp] = useState('');
   const messagesEndRef = useRef(null);
   const sessionIdRef = useRef(crypto.randomUUID());
 
@@ -34,12 +40,24 @@ const ChatBox = ({ selectedDoc }) => {
     const userMessage = input;
     setInput('');
     setError(null);
-    
+
+    const filters = {};
+    if (entity) filters.entity = entity;
+    if (irregularities)
+      filters.irregularities = irregularities
+        .split(',')
+        .map(t => t.trim())
+        .filter(Boolean);
+    if (startDate) filters.startDate = startDate;
+    if (endDate) filters.endDate = endDate;
+    if (followUp) filters.followUp = followUp;
+
     // Add user message to chat
     const payload = {
       message: userMessage,
       document_ids: [selectedDoc.id],
       session_id: sessionIdRef.current,
+      filters,
     };
     console.log('api.sendMessage payload:', JSON.stringify(payload));
 
@@ -51,7 +69,8 @@ const ChatBox = ({ selectedDoc }) => {
       const response = await api.sendMessage(
         userMessage,
         [selectedDoc.id],
-        sessionIdRef.current
+        sessionIdRef.current,
+        filters
       );
       console.log('api.sendMessage response:', response);
 
@@ -99,6 +118,37 @@ const ChatBox = ({ selectedDoc }) => {
             En analyse: <strong>{selectedDoc.title}</strong>
           </div>
         )}
+      </div>
+
+      <div className="chat-filters">
+        <input
+          type="text"
+          placeholder="Entity"
+          value={entity}
+          onChange={e => setEntity(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Irregularities (comma separated)"
+          value={irregularities}
+          onChange={e => setIrregularities(e.target.value)}
+        />
+        <input
+          type="date"
+          value={startDate}
+          onChange={e => setStartDate(e.target.value)}
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={e => setEndDate(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Follow-up state"
+          value={followUp}
+          onChange={e => setFollowUp(e.target.value)}
+        />
       </div>
 
       <div className="chat-messages">

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -46,7 +46,7 @@ export const api = {
   },
 
   // Chat with AI - matches your /api/chat endpoint
-  sendMessage: async (message, documentIds, sessionId) => {
+  sendMessage: async (message, documentIds, sessionId, filters = {}) => {
     const response = await fetch(`${API_BASE_URL}/api/chat`, {
       method: 'POST',
       headers: {
@@ -57,6 +57,7 @@ export const api = {
         document_ids: documentIds, // Backend expects snake_case
         documentIds, // Also send camelCase for compatibility
         session_id: sessionId || crypto.randomUUID(),
+        filters,
       }),
     });
     


### PR DESCRIPTION
## Summary
- allow users to select entity, irregularity tags, date range and follow-up state before chatting
- send filters with chat requests and backend forwards them to retrieval

## Testing
- `cd backend && npm test`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c709a4959c832b88e94ddc8bb7b73b