### PR TITLE
feat: add recommendations and follow-up schema

### DIFF
--- a/supabase/migrations/20241008130000_add_recommendations_and_follow_up.sql
+++ b/supabase/migrations/20241008130000_add_recommendations_and_follow_up.sql
@@ -1,0 +1,48 @@
+-- Create recommendations table
+CREATE TABLE recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id uuid REFERENCES reports(id) ON DELETE CASCADE,
+  text text NOT NULL,
+  target_entities text[],
+  irregularities text[],
+  deadline date,
+  follow_up_state text
+);
+
+-- Add follow-up columns to document_segments
+ALTER TABLE document_segments
+  ADD COLUMN observation_id uuid,
+  ADD COLUMN recommendation_id uuid REFERENCES recommendations(id),
+  ADD COLUMN response_to uuid REFERENCES recommendations(id),
+  ADD COLUMN amount_max numeric,
+  ADD COLUMN follow_up_state text;
+
+-- Enforce foreign keys on kg_edges
+ALTER TABLE kg_edges
+  ADD CONSTRAINT kg_edges_src_doc_id_fkey FOREIGN KEY (src_doc_id) REFERENCES documents(id) ON DELETE CASCADE,
+  ADD CONSTRAINT kg_edges_src_segment_id_fkey FOREIGN KEY (src_segment_id) REFERENCES document_segments(id) ON DELETE CASCADE;
+
+-- Restrict rel values and include new follow-up relations
+ALTER TABLE kg_edges DROP CONSTRAINT IF EXISTS kg_edges_rel_check;
+ALTER TABLE kg_edges
+  ADD CONSTRAINT kg_edges_rel_check CHECK (
+    rel IN (
+      'cites',
+      'distinguishes',
+      'follows',
+      'overrules',
+      'interprets',
+      'applies',
+      'implements',
+      'refersTo',
+      'discusses',
+      'targets',
+      'covers',
+      'addressesIrregularity',
+      'leadsTo',
+      'hasObservation',
+      'hasRecommendation',
+      'elicitsResponseFrom',
+      'respondsTo'
+    )
+  );


### PR DESCRIPTION
## Summary
- add recommendations table for structured follow-up data
- expand document_segments with observation, recommendation and follow-up fields
- constrain kg_edges relations and enforce foreign keys

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68c709a59650832bbf21f369b9dc2de8