### PR TITLE
Distinguish missing and unindexed documents

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -22,9 +22,7 @@ router.post('/chat', async (req, res) => {
 
   try {
     if (!Array.isArray(document_ids) || document_ids.length === 0) {
-      return res
-        .status(400)
-        .json({ error: 'No document selected or document not indexed' });
+      return res.status(400).json({ error: 'No document selected' });
     }
 
     // 1. Chargement des règles PAN
@@ -58,9 +56,7 @@ Si aucune source n'est fournie, indiquez-le clairement. Ne devinez jamais et n'i
       });
 
       if (!segments || segments.length === 0) {
-        return res
-          .status(400)
-          .json({ error: 'No document selected or document not indexed' });
+        return res.status(404).json({ error: 'Document not indexed' });
       }
 
       const contextText = segments
@@ -95,9 +91,7 @@ Si aucune source n'est fournie, indiquez-le clairement. Ne devinez jamais et n'i
       }
 
       if (!allChunks || allChunks.length === 0) {
-        return res
-          .status(400)
-          .json({ error: 'No document selected or document not indexed' });
+        return res.status(404).json({ error: 'Document not indexed' });
       }
 
       // 4. Similarité cosinus
@@ -115,9 +109,7 @@ Si aucune source n'est fournie, indiquez-le clairement. Ne devinez jamais et n'i
         .slice(0, 5);
 
       if (topChunks.length === 0) {
-        return res
-          .status(400)
-          .json({ error: 'No document selected or document not indexed' });
+        return res.status(404).json({ error: 'Document not indexed' });
       }
 
       const contextText = topChunks

--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -85,8 +85,13 @@ const ChatBox = ({ selectedDoc }) => {
       setError(err.message);
 
       let errorMessage = err.message;
-      if (errorMessage === 'No document selected or document not indexed') {
-        errorMessage += '. Please re-select or re-ingest the PDF.';
+      if (errorMessage === 'No document selected') {
+        errorMessage = 'No document selected. Please choose a document.';
+        toast.error(errorMessage);
+      } else if (errorMessage === 'Document not indexed') {
+        errorMessage += '. Please re-ingest the PDF.';
+        toast.error(errorMessage);
+      } else {
         toast.error(errorMessage);
       }
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -63,7 +63,16 @@ export const api = {
     
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.error || 'Failed to send message');
+      const message =
+        errorData.error ||
+        (response.status === 404
+          ? 'Document not indexed'
+          : response.status === 400
+          ? 'No document selected'
+          : 'Failed to send message');
+      const error = new Error(message);
+      error.status = response.status;
+      throw error;
     }
     
     return response.json();


### PR DESCRIPTION
## Summary
- Return 400 "No document selected" when chat requests lack document IDs
- Return 404 "Document not indexed" when retrieval yields no segments
- Surface specific backend errors on the client and show user-friendly toasts

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c70e25d078832bb60b1ef40f45a8ce