### PR TITLE
feat: add document type badges with caching

### DIFF
--- a/frontend/src/components/Sidebar/DocTypeBadge.jsx
+++ b/frontend/src/components/Sidebar/DocTypeBadge.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export const LABELS = {
+  lois_reglements: 'Lois & règlements',
+  jurisprudence: 'Jurisprudence',
+  doctrine: 'Doctrine',
+  rapports_publics: 'Rapports publics',
+  unknown: 'Type inconnu'
+};
+
+const DocTypeBadge = ({ type, status }) => {
+  let label = LABELS[type] || LABELS.unknown;
+  let className = 'doc-badge';
+
+  if (status === 'loading') {
+    className += ' doc-badge--loading';
+    label = '...';
+  } else if (status === 'error') {
+    className += ' doc-badge--error';
+    label = 'Erreur';
+  } else {
+    const typeClass = `doc-badge--${type || 'unknown'}`;
+    className += ` ${typeClass}`;
+  }
+
+  return <span className={className}>{label}</span>;
+};
+
+export default DocTypeBadge;

--- a/frontend/src/components/Sidebar/DocumentList.jsx
+++ b/frontend/src/components/Sidebar/DocumentList.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef, useState } from 'react';
+import DocTypeBadge from './DocTypeBadge';
+import { api } from '../../utils/api';
+
+const CACHE_KEY = 'barmai.docTypeCache.v1';
+const CACHE_TTL = 24 * 60 * 60 * 1000; // 24h in ms
+const CONCURRENT_LIMIT = 2;
+
+const DocumentList = ({ documents, selectedDoc, onSelectDoc }) => {
+  const [docTypes, setDocTypes] = useState({});
+  const queueRef = useRef([]);
+  const activeRef = useRef(0);
+  const cacheRef = useRef(null);
+
+  // Lazy load cache
+  if (cacheRef.current === null) {
+    try {
+      cacheRef.current = JSON.parse(localStorage.getItem(CACHE_KEY)) || {};
+    } catch {
+      cacheRef.current = {};
+    }
+  }
+
+  const saveCache = () => {
+    try {
+      localStorage.setItem(CACHE_KEY, JSON.stringify(cacheRef.current));
+    } catch {
+      // ignore write errors
+    }
+  };
+
+  const runQueue = () => {
+    while (activeRef.current < CONCURRENT_LIMIT && queueRef.current.length) {
+      const docId = queueRef.current.shift();
+      activeRef.current += 1;
+      api
+        .getDocumentType(docId)
+        .then((res) => {
+          const type = res.type || 'unknown';
+          setDocTypes((prev) => ({ ...prev, [docId]: { status: 'loaded', type } }));
+          cacheRef.current[docId] = { type, ts: Date.now() };
+          saveCache();
+        })
+        .catch(() => {
+          setDocTypes((prev) => ({ ...prev, [docId]: { status: 'error' } }));
+        })
+        .finally(() => {
+          activeRef.current -= 1;
+          runQueue();
+        });
+    }
+  };
+
+  useEffect(() => {
+    const now = Date.now();
+    documents.forEach((doc) => {
+      if (docTypes[doc.id]) return;
+      const cached = cacheRef.current[doc.id];
+      if (cached && now - cached.ts < CACHE_TTL) {
+        setDocTypes((prev) => ({ ...prev, [doc.id]: { status: 'loaded', type: cached.type } }));
+      } else {
+        queueRef.current.push(doc.id);
+        setDocTypes((prev) => ({ ...prev, [doc.id]: { status: 'loading' } }));
+      }
+    });
+    runQueue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [documents]);
+
+  return (
+    <div className="documents-list">
+      {documents.length === 0 ? (
+        <div className="empty-state">
+          <p>📄 Pas encore de document </p>
+          <p>Téléchargez un PDF pour commencer</p>
+        </div>
+      ) : (
+        documents.map((doc) => {
+          const info = docTypes[doc.id] || { status: 'loading' };
+          return (
+            <div
+              key={doc.id}
+              className={`document-item ${selectedDoc?.id === doc.id ? 'selected' : ''}`}
+              onClick={() => onSelectDoc(doc)}
+            >
+              <div className="doc-icon">📄</div>
+              <div className="doc-info">
+                <div className="doc-title">
+                  {doc.title} <DocTypeBadge type={info.type} status={info.status} />
+                </div>
+                <div className="doc-meta">
+                  PDF Document • {new Date(doc.uploaded_at).toLocaleDateString()}
+                </div>
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+};
+
+export default DocumentList;

--- a/frontend/src/components/Sidebar/index.jsx
+++ b/frontend/src/components/Sidebar/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import UploadButton from './UploadButton';
+import DocumentList from './DocumentList';
 import { api } from '../../utils/api';
 
 const Sidebar = ({ selectedDoc, onSelectDoc, onUpload, onDelete }) => {
@@ -98,30 +99,11 @@ const Sidebar = ({ selectedDoc, onSelectDoc, onUpload, onDelete }) => {
         </div>
       )}
 
-      <div className="documents-list">
-        {documents.length === 0 ? (
-          <div className="empty-state">
-            <p>📄 Pas encore de document </p>
-            <p>Téléchargez un PDF pour commencer</p>
-          </div>
-        ) : (
-          documents.map((doc) => (
-            <div
-              key={doc.id}
-              className={`document-item ${selectedDoc?.id === doc.id ? 'selected' : ''}`}
-              onClick={() => onSelectDoc(doc)}
-            >
-              <div className="doc-icon">📄</div>
-              <div className="doc-info">
-                <div className="doc-title">{doc.title}</div>
-                <div className="doc-meta">
-                  PDF Document • {new Date(doc.uploaded_at).toLocaleDateString()}
-                </div>
-              </div>
-            </div>
-          ))
-        )}
-      </div>
+      <DocumentList
+        documents={documents}
+        selectedDoc={selectedDoc}
+        onSelectDoc={onSelectDoc}
+      />
 
       {selectedDoc && (
         <div className="pdf-preview">

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -45,6 +45,18 @@ export const api = {
     return response.json();
   },
 
+  // Get document type - matches your /api/documents/:id/type endpoint
+  getDocumentType: async (documentId) => {
+    const response = await fetch(`${API_BASE_URL}/api/documents/${documentId}/type`);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || 'Failed to fetch document type');
+    }
+
+    return response.json();
+  },
+
   // Chat with AI - matches your /api/chat endpoint
   sendMessage: async (message, documentIds, sessionId, filters = {}) => {
     const response = await fetch(`${API_BASE_URL}/api/chat`, {


### PR DESCRIPTION
## Summary
- add document type badges and cache document types
- render document list with concurrent type fetch and caching
- delegate document list rendering to new component

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c77cfc53f0832b9590dba210eb5c19