### PR TITLE
feat: add document type preview helper

### DIFF
--- a/frontend/src/components/ChatBox/ChatHistory.jsx
+++ b/frontend/src/components/ChatBox/ChatHistory.jsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import ChatMessage from './ChatMessage';
+import { API_BASE_URL } from '../../utils/api';
 
 const ChatHistory = ({ documentId }) => {
   const [logs, setLogs] = useState([]);
@@ -20,7 +21,6 @@ const ChatHistory = ({ documentId }) => {
         setLoading(true);
         setError(null);
         
-        const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
         const response = await fetch(`${API_BASE_URL}/api/chatlogs/${documentId}`);
 
         if (!response.ok) {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,18 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
+export const API_BASE_URL = process.env.REACT_APP_API_BASE || 'http://localhost:5000';
+
+export const fetchDocumentTypePreview = async (documentId, { signal } = {}) => {
+  const params = new URLSearchParams({ document_id: documentId });
+  const response = await fetch(`${API_BASE_URL}/segment-preview?${params.toString()}`, {
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || 'Failed to fetch document type preview');
+  }
+
+  return response.json();
+};
 
 export const api = {
   // Upload PDF - matches your /api/upload endpoint
@@ -130,6 +144,9 @@ export const api = {
     console.log('✅ Notes loaded:', result);
     return result;
   },
+
+  // Fetch document type preview
+  fetchDocumentTypePreview,
 };
 
 // Helper function to format file size


### PR DESCRIPTION
## Summary
- add fetchDocumentTypePreview helper for /segment-preview endpoint
- standardize API base URL using REACT_APP_API_BASE and reuse in ChatHistory

## Testing
- `CI=true npm test` *(fails: Jest encountered an unexpected token in react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68c77ead6af0832ba3c0a58bb1926b7b