### PR TITLE
feat: add document badges and layout helpers

### DIFF
--- a/frontend/src/components/Sidebar/index.jsx
+++ b/frontend/src/components/Sidebar/index.jsx
@@ -113,7 +113,12 @@ const Sidebar = ({ selectedDoc, onSelectDoc, onUpload, onDelete }) => {
             >
               <div className="doc-icon">📄</div>
               <div className="doc-info">
-                <div className="doc-title">{doc.title}</div>
+                <div className="document-list__title-row">
+                  <div className="document-list__title">{doc.title}</div>
+                  <span className={`doc-badge doc-badge--${doc.type || 'pdf'}`}>
+                    {(doc.type || 'pdf').toUpperCase()}
+                  </span>
+                </div>
                 <div className="doc-meta">
                   PDF Document • {new Date(doc.uploaded_at).toLocaleDateString()}
                 </div>

--- a/frontend/src/styles/Sidebar.css
+++ b/frontend/src/styles/Sidebar.css
@@ -108,18 +108,64 @@
   flex: 1;
 }
 
-.doc-title {
+/* Document title row to align title and badge */
+.document-list__title-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 2px;
+  gap: 6px;
+}
+
+.document-list__title {
   font-weight: 500;
   color: #202124;
-  margin-bottom: 2px;
   font-size: 14px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
 }
 
 .doc-meta {
   font-size: 12px;
+  color: #5f6368;
+}
+
+/* Document type/status badge */
+.doc-badge {
+  padding: 2px 6px;
+  border-radius: 12px;
+  font-size: 10px;
+  font-weight: 500;
+  background: #e8eaed;
+  color: #5f6368;
+  flex-shrink: 0;
+}
+
+/* Status modifiers */
+.doc-badge--loading {
+  background: rgba(66, 133, 244, 0.1);
+  color: #4285f4;
+}
+
+.doc-badge--error {
+  background: #fdecea;
+  color: #d32f2f;
+}
+
+/* Type-based color variations */
+.doc-badge--pdf {
+  background: rgba(66, 133, 244, 0.1);
+  color: #4285f4;
+}
+
+.doc-badge--url {
+  background: rgba(52, 168, 83, 0.1);
+  color: #34a853;
+}
+
+.doc-badge--text {
+  background: rgba(154, 160, 166, 0.1);
   color: #5f6368;
 }
 


### PR DESCRIPTION
## Summary
- style document list titles and badges with new layout helpers
- add document badge component with status and type color variants

## Testing
- `CI=true npm test` *(fails: Jest encountered an unexpected token in react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68c77eae7340832bba6010888852f381