### PR TITLE
feat: allow optional session ids for chat

### DIFF
--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -12,6 +12,7 @@ const ChatBox = ({ selectedDoc }) => {
   const [loading, setLoading] = useState(false);
   const [, setError] = useState(null);
   const messagesEndRef = useRef(null);
+  const sessionIdRef = useRef(null);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -20,6 +21,15 @@ const ChatBox = ({ selectedDoc }) => {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  // Generate a new session identifier when the selected document changes
+  useEffect(() => {
+    if (selectedDoc) {
+      sessionIdRef.current = `${selectedDoc.id}-${Date.now()}`;
+    } else {
+      sessionIdRef.current = null;
+    }
+  }, [selectedDoc]);
 
   const handleSend = async () => {
     if (!input.trim()) return;
@@ -41,7 +51,8 @@ const ChatBox = ({ selectedDoc }) => {
   console.log('4. Document IDs array:', [selectedDoc.id]);
   console.log('5. About to call api.sendMessage with:', {
     message: userMessage,
-    documentIds: [selectedDoc.id]
+    documentIds: [selectedDoc.id],
+    sessionId: sessionIdRef.current
   });
   console.log('==============================');
 
@@ -50,7 +61,7 @@ const ChatBox = ({ selectedDoc }) => {
 
     try {
       // Call your real API
-      const response = await api.sendMessage(userMessage, [selectedDoc.id]);
+      const response = await api.sendMessage(userMessage, [selectedDoc.id], sessionIdRef.current);
       
       // Add AI response to chat
       setMessages(prev => [...prev, { 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -46,17 +46,22 @@ export const api = {
   },
 
   // Chat with AI - matches your /api/chat endpoint
-  sendMessage: async (message, documentIds) => {
+  // sessionId parameter is optional. If provided, it's sent in the payload
+  sendMessage: async (message, documentIds, sessionId) => {
+    const payload = {
+      message: message,
+      document_ids: documentIds, // Your backend expects this format
+    };
+    if (sessionId) {
+      payload.sessionid = sessionId;
+    }
+
     const response = await fetch(`${API_BASE_URL}/api/chat`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        message: message  ,
-        document_ids: documentIds, // Your backend expects this format
-        sessionid : "12122212"
-      }),
+      body: JSON.stringify(payload),
     });
     
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- make session identifiers optional in API sendMessage
- track session identifiers in ChatBox and pass through when available

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c77eaf3b08832b9fff6729d03f6885