### PR TITLE
feat: add document type badges

### DIFF
--- a/frontend/src/components/Sidebar/DocTypeBadge.jsx
+++ b/frontend/src/components/Sidebar/DocTypeBadge.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const TYPE_CONFIG = {
+  lois_reglements: {
+    label: 'Lois & règlements',
+    className: 'doc-badge--lois_reglements'
+  },
+  jurisprudence: {
+    label: 'Jurisprudence',
+    className: 'doc-badge--jurisprudence'
+  },
+  doctrine: {
+    label: 'Doctrine',
+    className: 'doc-badge--doctrine'
+  },
+  rapports_publics: {
+    label: 'Rapports publics',
+    className: 'doc-badge--rapports_publics'
+  },
+  unknown: {
+    label: 'Inconnu',
+    className: 'doc-badge--unknown'
+  }
+};
+
+const DocTypeBadge = ({ type = 'unknown' }) => {
+  const config = TYPE_CONFIG[type] || TYPE_CONFIG.unknown;
+  return (
+    <span className={`doc-badge ${config.className}`}>
+      {config.label}
+    </span>
+  );
+};
+
+export default DocTypeBadge;

--- a/frontend/src/components/Sidebar/index.jsx
+++ b/frontend/src/components/Sidebar/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import UploadButton from './UploadButton';
+import DocTypeBadge from './DocTypeBadge';
 import { api } from '../../utils/api';
 
 const Sidebar = ({ selectedDoc, onSelectDoc, onUpload, onDelete }) => {
@@ -115,9 +116,7 @@ const Sidebar = ({ selectedDoc, onSelectDoc, onUpload, onDelete }) => {
               <div className="doc-info">
                 <div className="document-list__title-row">
                   <div className="document-list__title">{doc.title}</div>
-                  <span className={`doc-badge doc-badge--${doc.type || 'pdf'}`}>
-                    {(doc.type || 'pdf').toUpperCase()}
-                  </span>
+                  <DocTypeBadge type={doc.type} />
                 </div>
                 <div className="doc-meta">
                   PDF Document • {new Date(doc.uploaded_at).toLocaleDateString()}

--- a/frontend/src/styles/Sidebar.css
+++ b/frontend/src/styles/Sidebar.css
@@ -169,6 +169,32 @@
   color: #5f6368;
 }
 
+/* Detected document type variations */
+.doc-badge--lois_reglements {
+  background: rgba(66, 133, 244, 0.1);
+  color: #1a73e8;
+}
+
+.doc-badge--jurisprudence {
+  background: rgba(52, 168, 83, 0.1);
+  color: #34a853;
+}
+
+.doc-badge--doctrine {
+  background: rgba(251, 188, 5, 0.1);
+  color: #fbbc05;
+}
+
+.doc-badge--rapports_publics {
+  background: rgba(171, 71, 188, 0.1);
+  color: #ab47bc;
+}
+
+.doc-badge--unknown {
+  background: rgba(154, 160, 166, 0.1);
+  color: #5f6368;
+}
+
 /* PDF Preview - Takes remaining space */
 .pdf-preview {
   flex: 1;


### PR DESCRIPTION
## Summary
- add DocTypeBadge component to display detected document types
- style badges for legal document categories
- use DocTypeBadge in sidebar document list

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `CI=true npm test -- --watchAll=false` (frontend) *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c780b13298832b89c95abf4463362d