### PR TITLE
feat: add document type badge

### DIFF
--- a/frontend/src/components/Sidebar/DocTypeBadge.jsx
+++ b/frontend/src/components/Sidebar/DocTypeBadge.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const TYPE_LABELS = {
+  lois_reglements: 'Lois & règlements',
+  jurisprudence: 'Jurisprudence',
+  doctrine: 'Doctrine',
+  rapports_publics: 'Rapports publics',
+  unknown: 'Unknown'
+};
+
+const DocTypeBadge = ({ type, state }) => {
+  const finalType = type || 'unknown';
+  const label = TYPE_LABELS[finalType] || TYPE_LABELS.unknown;
+
+  const classes = ['doc-badge'];
+  if (state === 'loading') {
+    classes.push('doc-badge--loading');
+  } else if (state === 'error') {
+    classes.push('doc-badge--error');
+  } else {
+    classes.push(`doc-badge--${finalType}`);
+  }
+
+  return <span className={classes.join(' ')}>{label}</span>;
+};
+
+export default DocTypeBadge;


### PR DESCRIPTION
## Summary
- add DocTypeBadge component mapping backend document types to human labels

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c7838d563c832bbbb3496ad6b167d8