### PR TITLE
Update segment preview API helper

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -2,7 +2,7 @@ export const API_BASE_URL = process.env.REACT_APP_API_BASE || 'http://localhost:
 
 export const fetchDocumentTypePreview = async (documentId, { signal } = {}) => {
   const params = new URLSearchParams({ document_id: documentId });
-  const response = await fetch(`${API_BASE_URL}/segment-preview?${params.toString()}`, {
+  const response = await fetch(`${API_BASE_URL}/api/segment-preview?${params.toString()}`, {
     signal,
   });
 
@@ -11,7 +11,12 @@ export const fetchDocumentTypePreview = async (documentId, { signal } = {}) => {
     throw new Error(errorData.error || 'Failed to fetch document type preview');
   }
 
-  return response.json();
+  const json = await response.json();
+
+  return {
+    type: json.detected_type || 'unknown',
+    human: json.detected_type_human || 'Inconnu',
+  };
 };
 
 export const api = {


### PR DESCRIPTION
## Summary
- use `/api/segment-preview` endpoint and normalize response
- expose `fetchDocumentTypePreview` as named export and in `api` object

## Testing
- `cd frontend && CI=true npm test` *(fails: Jest failed to parse ESM module react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68c7853de868832bbe27e0392809f495