### PR TITLE
feat: add document badge variants

### DIFF
--- a/frontend/src/styles/Sidebar.css
+++ b/frontend/src/styles/Sidebar.css
@@ -139,6 +139,7 @@
   font-weight: 500;
   background: #e8eaed;
   color: #5f6368;
+  border: 1px solid transparent;
   flex-shrink: 0;
 }
 
@@ -146,11 +147,13 @@
 .doc-badge--loading {
   background: rgba(66, 133, 244, 0.1);
   color: #4285f4;
+  border-color: #4285f4;
 }
 
 .doc-badge--error {
   background: #fdecea;
   color: #d32f2f;
+  border-color: #d32f2f;
 }
 
 /* Type-based color variations */
@@ -167,6 +170,36 @@
 .doc-badge--text {
   background: rgba(154, 160, 166, 0.1);
   color: #5f6368;
+}
+
+.doc-badge--lois_reglements {
+  background: rgba(26, 115, 232, 0.1);
+  color: #1a73e8;
+  border-color: #1a73e8;
+}
+
+.doc-badge--jurisprudence {
+  background: rgba(24, 128, 56, 0.1);
+  color: #188038;
+  border-color: #188038;
+}
+
+.doc-badge--doctrine {
+  background: rgba(156, 39, 176, 0.1);
+  color: #9c27b0;
+  border-color: #9c27b0;
+}
+
+.doc-badge--rapports_publics {
+  background: rgba(249, 171, 0, 0.1);
+  color: #f9ab00;
+  border-color: #f9ab00;
+}
+
+.doc-badge--unknown {
+  background: rgba(95, 99, 104, 0.1);
+  color: #5f6368;
+  border-color: #5f6368;
 }
 
 /* PDF Preview - Takes remaining space */


### PR DESCRIPTION
## Summary
- style new document types with dedicated badge colors
- include loading and error badge states and base border

## Testing
- `CI=true npm test` (fails: Jest encountered an unexpected token)


------
https://chatgpt.com/codex/tasks/task_e_68c786dccba0832b83f6d21449ceb5f9