### PR TITLE
Return document ID on upload and propagate to frontend

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -119,10 +119,11 @@ router.post('/upload', upload.single('file'), async (req, res) => {
     }
 
     fs.unlinkSync(file.path);
-    res.json({ 
-      message: 'PDF parsed, embedded, and uploaded successfully', 
-      public_url: publicURL, 
-      chunks: chunks.length 
+    res.json({
+      message: 'PDF parsed, embedded, and uploaded successfully',
+      public_url: publicURL,
+      chunks: chunks.length,
+      document: { id: docInsert.id }
     });
 
   } catch (err) {

--- a/frontend/src/components/Sidebar/UploadButton.jsx
+++ b/frontend/src/components/Sidebar/UploadButton.jsx
@@ -20,7 +20,7 @@ const UploadButton = ({ onUpload }) => {
       
       // Transform response to match your component's expected format
       const newDoc = {
-        id: result.document?.id || Date.now(), // Use actual ID from backend
+        id: result.id || result.document?.id, // Use actual ID from backend
         title: file.name,
         storage_url: result.public_url,
         uploaded_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- include document UUID in `/upload` response
- consume backend ID in upload button to keep new docs consistent

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `CI=true npm test --prefix frontend` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c78b477c40832ba68e7fa2aa39a74e