### PR TITLE
Use new document type fields for badge display

### DIFF
--- a/frontend/src/components/Sidebar/DocumentList.jsx
+++ b/frontend/src/components/Sidebar/DocumentList.jsx
@@ -72,8 +72,8 @@ const DocumentList = ({ documents, selectedDoc, onSelectDoc }) => {
         .then(res => {
           if (isCancelled) return;
           const entry = {
-            type: res.detected_type || 'pdf',
-            human: res.detected_type_human || 'PDF Document',
+            type: res.type || 'unknown',
+            human: res.human || 'Inconnu',
             ts: Date.now(),
           };
           setDocTypes(prev => ({


### PR DESCRIPTION
## Summary
- update Sidebar DocumentList to use `type` and `human` fields from document type preview API
- provide `unknown`/`Inconnu` defaults so badges show real values when fetched

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token in react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68c78be7ab34832b824cf4424ced0116