### PR TITLE
Validate document IDs before network calls

### DIFF
--- a/frontend/src/components/ChatBox/ChatHistory.jsx
+++ b/frontend/src/components/ChatBox/ChatHistory.jsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import ChatMessage from './ChatMessage';
-import { API_BASE_URL } from '../../utils/api';
+import { API_BASE_URL, UUID_RE } from '../../utils/api';
 
 const ChatHistory = ({ documentId }) => {
   const [logs, setLogs] = useState([]);
@@ -14,6 +14,12 @@ const ChatHistory = ({ documentId }) => {
     const fetchLogs = async () => {
       if (!documentId) {
         setLoading(false);
+        return;
+      }
+      if (!UUID_RE.test(documentId)) {
+        setLoading(false);
+        setError('Upload failed—please retry');
+        alert('Upload failed—please retry');
         return;
       }
 

--- a/frontend/src/components/Sidebar/DocumentList.jsx
+++ b/frontend/src/components/Sidebar/DocumentList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { fetchDocumentTypePreview } from '../../utils/api';
+import { fetchDocumentTypePreview, UUID_RE } from '../../utils/api';
 import DocTypeBadge from './DocTypeBadge';
 
 const CACHE_KEY = 'barmai.docTypeCache.v1';
@@ -45,6 +45,11 @@ const DocumentList = ({ documents, selectedDoc, onSelectDoc }) => {
     const seeded = {};
     const toFetch = [];
     for (const doc of documents) {
+      if (!UUID_RE.test(doc.id)) {
+        seeded[doc.id] = { loading: false, error: true };
+        alert('Upload failed—please retry');
+        continue;
+      }
       if (cache[doc.id]) {
         const { type, human, ts } = cache[doc.id];
         seeded[doc.id] = { type, human, ts, loading: false, error: null };

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,5 +1,8 @@
 export const API_BASE_URL = process.env.REACT_APP_API_BASE || 'http://localhost:5000';
 
+// UUID regex (same as backend)
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export const fetchDocumentTypePreview = async (documentId, { signal } = {}) => {
   const params = new URLSearchParams({ document_id: documentId });
   const response = await fetch(`${API_BASE_URL}/api/segment-preview?${params.toString()}`, {


### PR DESCRIPTION
## Summary
- add shared UUID regex and export it from api utilities
- skip document type preview requests if document id is invalid and alert the user
- prevent chat history fetch with invalid id and surface friendly warning

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token in react-markdown)*

------
https://chatgpt.com/codex/tasks/task_e_68c78c8eb504832ba435328b489442c2