### PR TITLE
Pass API sources to chat messages

### DIFF
--- a/frontend/src/components/ChatBox/ChatHistory.jsx
+++ b/frontend/src/components/ChatBox/ChatHistory.jsx
@@ -137,11 +137,12 @@ const ChatHistory = ({ documentId }) => {
               </div>
               {historyMessages.map((msg) => (
                 <div key={msg.id} className="history-message-wrapper">
-                  <ChatMessage 
-                    message={msg.message} 
+                  <ChatMessage
+                    message={msg.message}
                     isUser={msg.isUser}
                     timestamp={msg.timestamp}
                     isHistory={true}
+                    sources={msg.sources}
                   />
                   {msg.responseTime && !msg.isUser && (
                     <div className="response-time-badge">

--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -64,9 +64,10 @@ const ChatBox = ({ selectedDoc }) => {
       const response = await api.sendMessage(userMessage, [selectedDoc.id], sessionIdRef.current);
       
       // Add AI response to chat
-      setMessages(prev => [...prev, { 
-        message: response.reply, 
-        isUser: false 
+      setMessages(prev => [...prev, {
+        message: response.reply,
+        isUser: false,
+        sources: response.sources_used || []
       }]);
       
     } catch (err) {
@@ -112,11 +113,12 @@ const ChatBox = ({ selectedDoc }) => {
           </div>
         ) : (
           messages.map((msg, index) => (
-            <ChatMessage 
-              key={index} 
-              message={msg.message} 
-              isUser={msg.isUser} 
+            <ChatMessage
+              key={index}
+              message={msg.message}
+              isUser={msg.isUser}
               isError={msg.isError}
+              sources={msg.sources}
             />
           ))
         )}


### PR DESCRIPTION
## Summary
- include sources metadata when storing AI responses in ChatBox
- forward message sources to `ChatMessage` from ChatBox and ChatHistory

## Testing
- `CI=true npm test` *(fails: Jest could not parse ESM module `react-markdown`)*
- `npm test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_68c799cb3384832bb4026a3e8e00ff0d