### PR TITLE
Fix session_id handling for chat API

### DIFF
--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -60,8 +60,12 @@ const ChatBox = ({ selectedDoc }) => {
     setLoading(true);
 
     try {
+      const sessionId = sessionIdRef.current;
+      if (!sessionId) {
+        throw new Error('Missing sessionId');
+      }
       // Call your real API
-      const response = await api.sendMessage(userMessage, [selectedDoc.id], sessionIdRef.current);
+      const response = await api.sendMessage(userMessage, [selectedDoc.id], sessionId);
       
       // Add AI response to chat
       setMessages(prev => [...prev, {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -75,7 +75,7 @@ export const api = {
       document_ids: documentIds, // Your backend expects this format
     };
     if (sessionId) {
-      payload.sessionid = sessionId;
+      payload.session_id = sessionId;
     }
 
     const response = await fetch(`${API_BASE_URL}/api/chat`, {


### PR DESCRIPTION
## Summary
- Send `session_id` in chat API payload
- Ensure ChatBox validates sessionId before making requests

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c79d248a90832b8ee33e08143480d9