### PR TITLE
Fix frontend API base environment variable

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,6 @@
-export const API_BASE_URL = process.env.REACT_APP_API_BASE || 'http://localhost:5000';
+const configuredApiBase = process.env.REACT_APP_API_BASE_URL || process.env.REACT_APP_API_BASE;
+
+export const API_BASE_URL = (configuredApiBase || 'http://localhost:5000').replace(/\/$/, '');
 
 // UUID regex (same as backend)
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;


### PR DESCRIPTION
### Motivation
- The frontend was falling back to `http://localhost:5000` in production and returning “Failed to fetch” because the deployed environment provides `REACT_APP_API_BASE_URL` (not `REACT_APP_API_BASE`).

### Description
- Update `frontend/src/utils/api.js` to read `REACT_APP_API_BASE_URL` (falling back to `REACT_APP_API_BASE`) and normalize the base by removing a trailing slash before appending `/api/...` so the frontend uses the correct production backend URL.

### Testing
- Ran `npm run build` in `frontend` and the build completed successfully.
- Ran `npm test -- --watchAll=false` and tests failed due to an existing Jest/ESM transform issue with the `react-markdown` dependency, which is unrelated to this API base change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff77be1364832b86974d9c5b8effa8)