### PR TITLE
Ensure uploaded PDFs persist on parse/embedding failures and surface warnings

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -12,7 +12,9 @@ const { supabase } = require('../utils/supabaseClient');
 const SUPABASE_BUCKET = process.env.SUPABASE_BUCKET || 'documents';
 
 const router = express.Router();
-const upload = multer({ dest: 'uploads/' });
+const uploadDir = path.join(process.cwd(), 'uploads');
+fs.mkdirSync(uploadDir, { recursive: true });
+const upload = multer({ dest: uploadDir });
 
 function splitTextIntoChunks(text, maxWords = 500) {
   const sentences = text.split(/(?<=[.?!])\s+/);
@@ -21,13 +23,15 @@ function splitTextIntoChunks(text, maxWords = 500) {
 
   for (const sentence of sentences) {
     const words = sentence.split(/\s+/);
-    const chunkWords = chunk.join(' ').split(/\s+/).length;
+    const chunkWords = chunk.length > 0 ? chunk.join(' ').split(/\s+/).length : 0;
 
-    if ((chunkWords + words.length) > maxWords) {
+    if ((chunkWords + words.length) > maxWords && chunk.length > 0) {
       chunks.push(chunk.join(' '));
       chunk = [];
     }
-    chunk.push(sentence);
+    if (sentence.trim()) {
+      chunk.push(sentence);
+    }
   }
 
   if (chunk.length > 0) {
@@ -46,26 +50,27 @@ router.post('/upload', upload.single('file'), async (req, res) => {
   }
   console.log(`📄 File: "${file.originalname}" | ${file.size} bytes | ${file.mimetype}`);
 
+  let dataBuffer;
+  let uniqueFilename;
+  let publicURL;
+  let docInsert;
+  let parsedText = '';
+  let chunks = [];
+  const warnings = [];
+
   try {
-    // Step 1: PDF parse
-    console.log('📖 PDF parse: start');
-    const t0 = Date.now();
-    const dataBuffer = fs.readFileSync(file.path);
-    const parsedData = await pdfParse(dataBuffer);
-    console.log(`📖 PDF parse: done (${Date.now() - t0}ms)`);
+    dataBuffer = fs.readFileSync(file.path);
 
-    const chunks = splitTextIntoChunks(parsedData.text, 500);
-    console.log(`🔪 Chunks: ${chunks.length}`);
-
-    // Step 2: Storage upload
-    const fileExt = path.extname(file.originalname);
-    const uniqueFilename = `${crypto.randomUUID()}${fileExt}`;
+    // Step 1: Storage upload first so the PDF remains visible even if text
+    // extraction or embedding fails for scanned/encrypted/malformed files.
+    const fileExt = path.extname(file.originalname) || '.pdf';
+    uniqueFilename = `${crypto.randomUUID()}${fileExt}`;
     console.log(`📤 Storage upload: start → bucket="${SUPABASE_BUCKET}"`);
     const t1 = Date.now();
     const { error: uploadErr } = await supabase.storage
       .from(SUPABASE_BUCKET)
       .upload(uniqueFilename, dataBuffer, {
-        contentType: file.mimetype,
+        contentType: file.mimetype || 'application/pdf',
       });
     console.log(`📤 Storage upload: done (${Date.now() - t1}ms)`);
 
@@ -74,25 +79,44 @@ router.post('/upload', upload.single('file'), async (req, res) => {
       return res.status(500).json({ error: 'Failed to upload file to storage' });
     }
 
-    // Step 3: Public URL
+    // Step 2: Public URL
     const { data: publicURLData } = supabase
       .storage
       .from(SUPABASE_BUCKET)
       .getPublicUrl(uniqueFilename);
-    const publicURL = publicURLData.publicUrl;
+    publicURL = publicURLData.publicUrl;
     console.log('🌐 Public URL generated');
+
+    // Step 3: Best-effort PDF parse. Uploads should not disappear simply
+    // because a PDF has no extractable text or pdf-parse cannot read it.
+    try {
+      console.log('📖 PDF parse: start');
+      const t0 = Date.now();
+      const parsedData = await pdfParse(dataBuffer);
+      parsedText = (parsedData.text || '').trim();
+      chunks = parsedText ? splitTextIntoChunks(parsedText, 500).filter(Boolean) : [];
+      console.log(`📖 PDF parse: done (${Date.now() - t0}ms)`);
+      console.log(`🔪 Chunks: ${chunks.length}`);
+
+      if (!parsedText) {
+        warnings.push('The PDF was uploaded, but no extractable text was found. If this is a scanned PDF, OCR is required before it can be searched or used in chat.');
+      }
+    } catch (parseErr) {
+      console.error('❌ PDF parse error:', parseErr.message);
+      warnings.push('The PDF was uploaded, but its text could not be extracted. It will appear in the document list, but search/chat context may be unavailable until the PDF is fixed or OCR is added.');
+    }
 
     // Step 4: Document DB insert
     console.log('💾 Document insert: start');
     const t2 = Date.now();
-    const { data: docInsert, error: insertErr } = await supabase
+    const { data: insertedDoc, error: insertErr } = await supabase
       .from('documents')
       .insert([
         {
           name: file.originalname,
           storage_path: uniqueFilename,
           storage_url: publicURL,
-          full_text: parsedData.text
+          full_text: parsedText
         }
       ])
       .select()
@@ -103,45 +127,73 @@ router.post('/upload', upload.single('file'), async (req, res) => {
       console.error('❌ Document insert error:', insertErr.message);
       return res.status(500).json({ error: 'Failed to store document' });
     }
+    docInsert = insertedDoc;
 
-    // Step 5: Embeddings loop
-    console.log(`🧠 Embedding loop: start (${chunks.length} chunks)`);
-    const t3 = Date.now();
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      const te = Date.now();
-      console.log(`  🔄 Chunk ${i + 1}/${chunks.length}: embedding...`);
+    // Step 5: Best-effort embeddings loop. A file that was stored and indexed in
+    // documents should still be returned to the UI if OpenAI or chunk insertion fails.
+    if (chunks.length > 0) {
+      try {
+        console.log(`🧠 Embedding loop: start (${chunks.length} chunks)`);
+        const t3 = Date.now();
+        for (let i = 0; i < chunks.length; i++) {
+          const chunk = chunks[i];
+          const te = Date.now();
+          console.log(`  🔄 Chunk ${i + 1}/${chunks.length}: embedding...`);
 
-      const embeddingResponse = await openai.embeddings.create({
-        model: 'text-embedding-3-small',
-        input: chunk,
-        encoding_format: 'float'
-      });
-      const embedding = embeddingResponse.data[0].embedding;
-      console.log(`  ✅ Chunk ${i + 1} embedded (${Date.now() - te}ms)`);
+          const embeddingResponse = await openai.embeddings.create({
+            model: 'text-embedding-3-small',
+            input: chunk,
+            encoding_format: 'float'
+          });
+          const embedding = embeddingResponse.data[0].embedding;
+          console.log(`  ✅ Chunk ${i + 1} embedded (${Date.now() - te}ms)`);
 
-      const { error: chunkErr } = await supabase
-        .from('document_chunks')
-        .insert([{ document_id: docInsert.id, content: chunk, embedding }]);
+          const { error: chunkErr } = await supabase
+            .from('document_chunks')
+            .insert([{ document_id: docInsert.id, content: chunk, embedding }]);
 
-      if (chunkErr) {
-        console.error(`  ❌ Chunk ${i + 1} insert error:`, chunkErr.message);
+          if (chunkErr) {
+            throw new Error(`Chunk ${i + 1} insert error: ${chunkErr.message}`);
+          }
+        }
+        console.log(`🧠 Embedding loop: done (${Date.now() - t3}ms total)`);
+      } catch (embedErr) {
+        console.error('❌ Embedding error:', embedErr.message);
+        warnings.push('The PDF was uploaded and text was extracted, but embeddings could not be created. It may appear in the list but not work in semantic chat/search yet.');
       }
+    } else {
+      console.log('🧠 Embedding loop skipped: no text chunks available');
     }
-    console.log(`🧠 Embedding loop: done (${Date.now() - t3}ms total)`);
 
-    fs.unlinkSync(file.path);
     console.log('✅ Upload complete, sending response');
-    res.json({
-      message: 'PDF parsed, embedded, and uploaded successfully',
+    return res.json({
+      message: warnings.length
+        ? 'PDF uploaded with warnings'
+        : 'PDF parsed, embedded, and uploaded successfully',
+      warnings,
       public_url: publicURL,
       chunks: chunks.length,
-      document: { id: docInsert.id }
+      text_content: parsedText,
+      document: {
+        id: docInsert.id,
+        title: docInsert.name,
+        uploaded_at: docInsert.created_at,
+        storage_url: docInsert.storage_url,
+        text_content: docInsert.full_text || parsedText
+      }
     });
 
   } catch (err) {
     console.error('❌ Upload handler error:', err.message);
-    res.status(500).json({ error: 'Failed to parse and embed PDF' });
+    return res.status(500).json({ error: 'Failed to upload PDF' });
+  } finally {
+    if (file?.path) {
+      fs.unlink(file.path, (unlinkErr) => {
+        if (unlinkErr) {
+          console.error('⚠️ Failed to clean up temp upload:', unlinkErr.message);
+        }
+      });
+    }
   }
 });
 

--- a/frontend/src/components/Sidebar/UploadButton.jsx
+++ b/frontend/src/components/Sidebar/UploadButton.jsx
@@ -22,13 +22,17 @@ const UploadButton = ({ onUpload }) => {
       // Transform response to match your component's expected format
       const newDoc = {
         id: result.id || result.document?.id, // Use actual ID from backend
-        title: file.name,
-        storage_url: result.public_url,
-        uploaded_at: new Date().toISOString(),
-        text_content: result.text_content || ''
+        title: result.document?.title || file.name,
+        storage_url: result.document?.storage_url || result.public_url,
+        uploaded_at: result.document?.uploaded_at || new Date().toISOString(),
+        text_content: result.document?.text_content || result.text_content || ''
       };
 
       onUpload(newDoc);
+
+      if (result.warnings?.length) {
+        alert(result.warnings.join('\n\n'));
+      }
 
     } catch (error) {
       console.error('❌ Upload error:', error.message);


### PR DESCRIPTION
### Motivation
- Prevent uploads from disappearing when `pdf-parse` or embedding fails by making storage the primary persistence step. 
- Make text extraction and embeddings best-effort operations so partially-processed PDFs are still visible and manageable. 
- Give the frontend enough metadata and warnings to show uploaded documents immediately and inform the user when further processing failed. 

### Description
- Change backend upload flow to upload the raw file to Supabase first and generate a public URL before attempting text extraction or embeddings (modified `backend/routes/upload.js`).
- Make parsing and embedding best-effort: both are wrapped in `try/catch` and failures are collected in a `warnings` array that is returned to the frontend instead of failing the whole request.
- Insert a document record after storage using the extracted text when available, and return full document metadata plus `warnings`, `public_url`, `chunks`, and `text_content` in the upload response.
- Add safer temp upload handling by creating `uploads` directory via `fs.mkdirSync(...)` and cleaning up the temp file in a `finally` block, and default content type to `'application/pdf'` when missing.
- Improve chunking to avoid empty chunks and trimmed sentences, and update the frontend `UploadButton` (`frontend/src/components/Sidebar/UploadButton.jsx`) to use backend-returned document metadata and display any `warnings` as an alert.

### Testing
- Ran `node --check backend/routes/upload.js` and it completed with no syntax errors.
- Built the frontend with `npm --prefix frontend run build` and the production build completed successfully.
- No automated unit tests exist for the upload flow in this repo; manual smoke testing was performed via the build and syntax checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff79bb6850832b870c62fd9a892f0c)