### PR TITLE
feat(chat): stream AI responses token-by-token (ChatGPT-style)

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -115,23 +115,25 @@ function cosineSimilarity(a, b) {
   return dot / (normA * normB || 1e-8);
 }
 
-/* ----------------------------------------- Route ----------------------------------------- */
+/* ------------------------------------- Shared pipeline ------------------------------------- */
 
-router.post('/chat', async (req, res) => {
-  const { message, document_ids, session_id, vulgarisation = false } = req.body;
-  const startTime = Date.now();
+/**
+ * Runs retrieval for the selected documents and builds the numbered context
+ * plus the source_map used by the UI. Shared by both the buffered (/chat) and
+ * streaming (/chat/stream) endpoints.
+ *
+ * Returns one of:
+ *   { kind: 'context', contextText, retrieval_mode, sourcesUsed, source_map }
+ *   { kind: 'empty', reply, retrieval_mode }            // nothing to answer from
+ *   { kind: 'error', status, body }                     // upstream failure
+ */
+async function buildChatContext({ message, document_ids }) {
+  let contextText = '';
+  let retrieval_mode = USE_GRAPH ? 'graph' : 'chunks';
+  let sourcesUsed = [];
+  let source_map = {};
 
-  if (!Array.isArray(document_ids) || document_ids.length === 0) {
-    return res.status(400).json({ error: 'No document_ids provided' });
-  }
-
-  try {
-    let contextText = '';
-    let retrieval_mode = USE_GRAPH ? 'graph' : 'chunks';
-    let sourcesUsed = [];
-    let source_map = {};
-
-    if (USE_GRAPH) {
+  if (USE_GRAPH) {
       // GRAPH MODE
       const {
         contextText: ctx,
@@ -170,7 +172,7 @@ router.post('/chat', async (req, res) => {
           .in('id', ids);
         if (docsErr) {
           console.error('❌ Error fetching document titles:', docsErr.message);
-          return res.status(500).json({ error: 'Error fetching document titles' });
+          return { kind: 'error', status: 500, body: { error: 'Error fetching document titles' } };
         }
         (docs || []).forEach(d => { docsById[d.id] = d; });
       } else if (fallbackDocId) {
@@ -185,7 +187,7 @@ router.post('/chat', async (req, res) => {
 
       source_map = buildSourceMap({ sourcesUsed, docsById });
 
-    } else {
+  } else {
       // ------------------------- LEGACY CHUNK MODE -------------------------
       // 1) Embed question
       const embedQ = await openai.embeddings.create({
@@ -203,18 +205,16 @@ router.post('/chat', async (req, res) => {
 
       if (fetchErr) {
         console.error('❌ Error fetching chunks:', fetchErr.message);
-        return res.status(500).json({ error: 'Error fetching chunks' });
+        return { kind: 'error', status: 500, body: { error: 'Error fetching chunks' } };
       }
 
       const chunksArr = Array.isArray(allChunks) ? allChunks : [];
       if (!chunksArr.length) {
-        return res.status(200).json({
-          reply: "Aucun ‘chunk’ n’a été trouvé pour ces documents. Veuillez (ré)indexer le document.",
-          response_time_ms: Date.now() - startTime,
+        return {
+          kind: 'empty',
           retrieval_mode,
-          sources_used: [],
-          source_map: {}
-        });
+          reply: "Aucun ‘chunk’ n’a été trouvé pour ces documents. Veuillez (ré)indexer le document."
+        };
       }
 
       // 3) Similarity
@@ -240,7 +240,7 @@ router.post('/chat', async (req, res) => {
 
       if (docsErr) {
         console.error('❌ Error fetching document titles:', docsErr.message);
-        return res.status(500).json({ error: 'Error fetching document titles' });
+        return { kind: 'error', status: 500, body: { error: 'Error fetching document titles' } };
       }
       const docsById = {};
       (docs || []).forEach(d => { docsById[d.id] = d; });
@@ -253,9 +253,17 @@ router.post('/chat', async (req, res) => {
 
       // 7) Build source_map for UI chips
       source_map = buildSourceMap({ sourcesUsed, docsById });
-    }
+  }
 
-    // 8) Rules
+  return { kind: 'context', contextText, retrieval_mode, sourcesUsed, source_map };
+}
+
+/**
+ * Builds the OpenAI chat-completion parameters (system + user prompt) shared
+ * by the buffered and streaming endpoints. `stream` toggles token streaming.
+ */
+function buildCompletionParams({ contextText, message, vulgarisation, stream = false }) {
+    // Rules
     const rulesText = rules?.PAN_rules?.instruction_summary || '';
     const systemPrompt = `
 ${rulesText}
@@ -273,15 +281,15 @@ RÈGLES OBLIGATOIRES
       ? "Mode vulgarisation activé. Réponds de manière simple.\n\n" + message
       : message;
 
-    // 9) Completion
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      temperature: 0.2,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        {
-          role: 'user',
-          content:
+  return {
+    model: 'gpt-3.5-turbo',
+    temperature: 0.2,
+    stream,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      {
+        role: 'user',
+        content:
 `CONTEXTE (numéroté) :
 ${contextText}
 
@@ -299,36 +307,70 @@ RÈGLES :
 - Entourez les points clés (termes, chiffres, articles) avec la balise <mark>…</mark> (max 6).
 - Chaque ligne DOIT contenir au moins un marqueur de source 【n】 correspondant au CONTEXTE.
 - Si le point n'est pas couvert par le contexte, écrivez : "Les documents fournis ne traitent pas de ce point."`
-        }
-      ]
-    });
+      }
+    ]
+  };
+}
+
+// Persist a finished exchange to chat_logs (best-effort, never throws).
+async function logChat({ req, session_id, document_ids, message, finalReply, responseTime }) {
+  try {
+    const { error: logError } = await supabase
+      .from('chat_logs')
+      .insert([{
+        session_id: session_id || null,
+        document_id: document_ids[0],
+        user_message: message,
+        ai_response: finalReply,
+        response_time_ms: responseTime,
+        user_ip: req.ip || req.connection?.remoteAddress,
+        user_agent: req.get('User-Agent')
+      }]);
+    if (logError) console.error('⚠️ Failed to save chat log:', logError.message);
+    else console.log('✅ Chat log saved');
+  } catch (logErr) {
+    console.error('⚠️ Chat logging error:', logErr);
+  }
+}
+
+/* ----------------------------------------- Routes ----------------------------------------- */
+
+// Buffered endpoint — returns the full answer in one JSON payload (unchanged behavior).
+router.post('/chat', async (req, res) => {
+  const { message, document_ids, session_id, vulgarisation = false } = req.body;
+  const startTime = Date.now();
+
+  if (!Array.isArray(document_ids) || document_ids.length === 0) {
+    return res.status(400).json({ error: 'No document_ids provided' });
+  }
+
+  try {
+    const ctx = await buildChatContext({ message, document_ids });
+
+    if (ctx.kind === 'error') return res.status(ctx.status).json(ctx.body);
+    if (ctx.kind === 'empty') {
+      return res.status(200).json({
+        reply: ctx.reply,
+        response_time_ms: Date.now() - startTime,
+        retrieval_mode: ctx.retrieval_mode,
+        sources_used: [],
+        source_map: {}
+      });
+    }
+
+    const { contextText, retrieval_mode, sourcesUsed, source_map } = ctx;
+
+    const completion = await openai.chat.completions.create(
+      buildCompletionParams({ contextText, message, vulgarisation, stream: false })
+    );
 
     const aiResponse = completion.choices[0].message.content;
     let finalReply = appendSourcesIfMissing(aiResponse, contextText);
     finalReply = ensureHighlights(finalReply);
 
     const responseTime = Date.now() - startTime;
+    await logChat({ req, session_id, document_ids, message, finalReply, responseTime });
 
-    // 10) Save log (best-effort)
-    try {
-      const { error: logError } = await supabase
-        .from('chat_logs')
-        .insert([{
-          session_id: session_id || null,
-          document_id: document_ids[0],
-          user_message: message,
-          ai_response: finalReply,
-          response_time_ms: responseTime,
-          user_ip: req.ip || req.connection?.remoteAddress,
-          user_agent: req.get('User-Agent')
-        }]);
-      if (logError) console.error('⚠️ Failed to save chat log:', logError.message);
-      else console.log('✅ Chat log saved');
-    } catch (logErr) {
-      console.error('⚠️ Chat logging error:', logErr);
-    }
-
-    // 11) API response (includes source_map for clickable chips)
     res.json({
       reply: finalReply,
       response_time_ms: responseTime,
@@ -340,6 +382,87 @@ RÈGLES :
   } catch (err) {
     console.error('❌ /api/chat error:', err);
     res.status(500).json({ error: 'Failed to generate chat response' });
+  }
+});
+
+/* ----------------------------------- Streaming endpoint ----------------------------------- */
+
+// Server-Sent Events stream. Emits, in order:
+//   event: meta   { retrieval_mode, source_map }   — sent before any token
+//   event: delta  { text }                          — one per token chunk
+//   event: done   { reply, response_time_ms, sources_used }  — post-processed answer
+//   event: error  { error }                         — on failure
+router.post('/chat/stream', async (req, res) => {
+  const { message, document_ids, session_id, sessionid, vulgarisation = false } = req.body;
+  const sid = session_id || sessionid || null;
+  const startTime = Date.now();
+
+  if (!Array.isArray(document_ids) || document_ids.length === 0) {
+    return res.status(400).json({ error: 'No document_ids provided' });
+  }
+
+  // Open the SSE channel.
+  res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // disable proxy buffering (nginx)
+  if (typeof res.flushHeaders === 'function') res.flushHeaders();
+
+  const send = (event, data) => {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
+
+  try {
+    const ctx = await buildChatContext({ message, document_ids });
+
+    if (ctx.kind === 'error') {
+      send('error', ctx.body);
+      return res.end();
+    }
+    if (ctx.kind === 'empty') {
+      send('meta', { retrieval_mode: ctx.retrieval_mode, source_map: {} });
+      send('delta', { text: ctx.reply });
+      send('done', {
+        reply: ctx.reply,
+        response_time_ms: Date.now() - startTime,
+        sources_used: []
+      });
+      return res.end();
+    }
+
+    const { contextText, retrieval_mode, sourcesUsed, source_map } = ctx;
+
+    // Send retrieval metadata up front so the UI can render source chips immediately.
+    send('meta', { retrieval_mode, source_map });
+
+    const stream = await openai.chat.completions.create(
+      buildCompletionParams({ contextText, message, vulgarisation, stream: true })
+    );
+
+    let aiResponse = '';
+    for await (const part of stream) {
+      const delta = part?.choices?.[0]?.delta?.content || '';
+      if (delta) {
+        aiResponse += delta;
+        send('delta', { text: delta });
+      }
+    }
+
+    // Post-process the complete answer the same way the buffered route does.
+    let finalReply = appendSourcesIfMissing(aiResponse, contextText);
+    finalReply = ensureHighlights(finalReply);
+
+    const responseTime = Date.now() - startTime;
+    await logChat({ req, session_id: sid, document_ids, message, finalReply, responseTime });
+
+    send('done', { reply: finalReply, response_time_ms: responseTime, sources_used: sourcesUsed });
+    res.end();
+
+  } catch (err) {
+    console.error('❌ /api/chat/stream error:', err);
+    // Headers are already sent, so surface the failure over the open SSE channel.
+    send('error', { error: 'Failed to generate chat response' });
+    res.end();
   }
 });
 

--- a/frontend/src/components/ChatBox/ChatMessage.jsx
+++ b/frontend/src/components/ChatBox/ChatMessage.jsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 
-const ChatMessage = ({ message, isUser, timestamp, isHistory = false, isError = false, sourceMap = {} }) => {
+const ChatMessage = ({ message, isUser, timestamp, isHistory = false, isError = false, streaming = false, sourceMap = {} }) => {
   const [copiedKey, setCopiedKey] = useState(null);
 
   const formatTime = (ts) => {
@@ -29,7 +29,7 @@ const ChatMessage = ({ message, isUser, timestamp, isHistory = false, isError = 
   const entries = Object.entries(sourceMap || {}); // [["1",{doc_id,...}], ...]
 
   return (
-    <div className={`message ${isUser ? 'user-message' : 'ai-message'} ${isHistory ? 'history-message' : ''} ${isError ? 'is-error' : ''}`}>
+    <div className={`message ${isUser ? 'user-message' : 'ai-message'} ${isHistory ? 'history-message' : ''} ${isError ? 'is-error' : ''} ${streaming ? 'is-streaming' : ''}`}>
       <div className="message-avatar">
         {isUser ? '👤' : '🟢'}
       </div>
@@ -79,8 +79,11 @@ const ChatMessage = ({ message, isUser, timestamp, isHistory = false, isError = 
             {message || ''}
           </ReactMarkdown>
 
-          {/* Source chips (if backend sent `source_map`) */}
-          {!isUser && entries.length > 0 && (
+          {/* Blinking caret while the answer is still streaming in */}
+          {streaming && <span className="stream-caret" aria-hidden="true" />}
+
+          {/* Source chips (if backend sent `source_map`) — only once streaming is done */}
+          {!isUser && !streaming && entries.length > 0 && (
             <div className="source-chips">
               {entries.map(([key, meta]) => {
                 const label = `【${key}】 ${meta?.doc_title || 'Source'}`;

--- a/frontend/src/components/ChatBox/index.jsx
+++ b/frontend/src/components/ChatBox/index.jsx
@@ -68,36 +68,73 @@ const ChatBox = ({ selectedDoc }) => {
     ]);
     setLoading(true);
 
-    try {
-      // Call your real API
-      const response = await api.sendMessage(userMessage, [selectedDoc.id], sessionIdRef.current);
-
-      // Add AI response to chat (include source_map from backend)
+    // The AI bubble we progressively fill as tokens stream in, addressed by a
+    // stable id. `created` is a synchronous guard so rapid deltas can't append
+    // duplicate bubbles before the first append has flushed to state.
+    const aiId = `ai-${Date.now()}`;
+    let created = false;
+    const ensureAiMessage = () => {
+      if (created) return;
+      created = true;
       setMessages(prev => [
         ...prev,
         {
-          message: response.reply,
+          id: aiId,
+          message: '',
           isUser: false,
-          sourceMap: response.source_map || {},
+          sourceMap: {},
+          streaming: true,
           timestamp: Date.now()
         }
       ]);
+      setLoading(false); // first event arrived: swap the typing dots for live text
+    };
+    const updateAi = (patch) => {
+      setMessages(prev => prev.map(m =>
+        m.id === aiId ? { ...m, ...(typeof patch === 'function' ? patch(m) : patch) } : m
+      ));
+    };
+
+    try {
+      await api.sendMessageStream(userMessage, [selectedDoc.id], sessionIdRef.current, {
+        onMeta: ({ source_map }) => {
+          ensureAiMessage();
+          updateAi({ sourceMap: source_map || {} });
+        },
+        onDelta: (text) => {
+          ensureAiMessage();
+          updateAi(m => ({ message: m.message + text }));
+        },
+        onDone: ({ reply, source_map }) => {
+          ensureAiMessage();
+          updateAi(m => ({
+            // Prefer the post-processed reply (highlights + sources) when present.
+            message: reply ?? m.message,
+            sourceMap: source_map || m.sourceMap || {},
+            streaming: false
+          }));
+        }
+      });
 
     } catch (err) {
       console.error('Chat error:', err);
       setError(err.message);
 
-      // Add error message to chat
-      setMessages(prev => [
-        ...prev,
-        {
-          message: `Sorry, I encountered an error: ${err.message}`,
-          isUser: false,
-          isError: true,
-          sourceMap: null,
-          timestamp: Date.now()
-        }
-      ]);
+      if (created) {
+        // Stream started then failed: turn the in-progress bubble into an error.
+        updateAi({ message: `Sorry, I encountered an error: ${err.message}`, isError: true, streaming: false });
+      } else {
+        setMessages(prev => [
+          ...prev,
+          {
+            message: `Sorry, I encountered an error: ${err.message}`,
+            isUser: false,
+            isError: true,
+            sourceMap: null,
+            timestamp: Date.now()
+          }
+        ]);
+      }
     } finally {
       setLoading(false);
     }
@@ -140,6 +177,7 @@ const ChatBox = ({ selectedDoc }) => {
               message={msg.message}
               isUser={msg.isUser}
               isError={msg.isError}
+              streaming={msg.streaming}
               sourceMap={msg.sourceMap}
               timestamp={msg.timestamp}
             />

--- a/frontend/src/styles/ChatBox.css
+++ b/frontend/src/styles/ChatBox.css
@@ -215,6 +215,23 @@
 .typing-indicator span:nth-child(2) { animation-delay: 0.18s; }
 .typing-indicator span:nth-child(3) { animation-delay: 0.36s; }
 
+/* Blinking caret shown at the end of a streaming AI answer (ChatGPT-style) */
+.stream-caret {
+  display: inline-block;
+  width: 7px;
+  height: 1.05em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: var(--accent);
+  border-radius: 1px;
+  animation: stream-caret-blink 1s steps(2, start) infinite;
+}
+
+@keyframes stream-caret-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
 /* ===== Chat Input ===== */
 .chat-input-container {
   padding: 14px 16px;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -92,8 +92,83 @@ export const api = {
       const errorData = await response.json().catch(() => ({}));
       throw new Error(errorData.error || 'Failed to send message');
     }
-    
+
     return response.json();
+  },
+
+  // Streamed chat - matches your /api/chat/stream (SSE) endpoint.
+  // Reads tokens as they are generated and reports them via callbacks:
+  //   onMeta({ retrieval_mode, source_map })  — once, before any token
+  //   onDelta(text)                            — per token chunk
+  //   onDone({ reply, response_time_ms, sources_used }) — final processed answer
+  // Resolves once the stream ends; rejects on transport/HTTP errors.
+  sendMessageStream: async (
+    message,
+    documentIds,
+    sessionId,
+    { onMeta, onDelta, onDone, signal } = {}
+  ) => {
+    const payload = {
+      message,
+      document_ids: documentIds,
+    };
+    if (sessionId) {
+      payload.session_id = sessionId;
+    }
+
+    const response = await fetch(`${API_BASE_URL}/api/chat/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal,
+    });
+
+    if (!response.ok || !response.body) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || 'Failed to send message');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let streamError = null;
+
+    const dispatch = (event, data) => {
+      if (event === 'meta') onMeta?.(data);
+      else if (event === 'delta') onDelta?.(data?.text ?? '');
+      else if (event === 'done') onDone?.(data);
+      else if (event === 'error') streamError = new Error(data?.error || 'Stream error');
+    };
+
+    // SSE frames are separated by a blank line; each frame has `event:`/`data:` lines.
+    const flushFrame = (frame) => {
+      let event = 'message';
+      let dataStr = '';
+      for (const line of frame.split('\n')) {
+        if (line.startsWith('event:')) event = line.slice(6).trim();
+        else if (line.startsWith('data:')) dataStr += line.slice(5).trim();
+      }
+      if (!dataStr) return;
+      let data;
+      try { data = JSON.parse(dataStr); } catch { data = dataStr; }
+      dispatch(event, data);
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let sep;
+      while ((sep = buffer.indexOf('\n\n')) !== -1) {
+        const frame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        if (frame.trim()) flushFrame(frame);
+      }
+    }
+    if (buffer.trim()) flushFrame(buffer);
+
+    if (streamError) throw streamError;
   },
 
   // Generate mind map - matches your /api/mindmap endpoint


### PR DESCRIPTION
## What & why

The chat answer used to appear as one block once the whole OpenAI completion finished. This adds **real Server-Sent Events (SSE) streaming** so the answer renders progressively, token-by-token, the way ChatGPT does — while keeping the existing `react-markdown` rendering so paragraphs/lists/tables still format nicely (and now format *live* as text arrives).

This is true streaming (server pushes tokens as the model generates them), not a cosmetic client-side typewriter.

## Backend — `backend/routes/chat.js`
- Refactored the retrieval + prompt-building logic into shared helpers (`buildChatContext`, `buildCompletionParams`, `logChat`) so both endpoints share one code path.
- New `POST /api/chat/stream` emits SSE events:
  - `meta` — `{ retrieval_mode, source_map }`, sent up front so source chips can render immediately
  - `delta` — `{ text }`, one per token chunk
  - `done` — `{ reply, response_time_ms, sources_used }`, the post-processed answer (highlights + appended sources, same as before)
  - `error` — surfaced over the open channel if generation fails mid-stream
- The original buffered `POST /api/chat` endpoint is **unchanged** (still returns one JSON payload), so nothing else that relies on it breaks.

## Frontend
- `api.sendMessageStream` reads the SSE body via the fetch reader and dispatches `onMeta` / `onDelta` / `onDone` callbacks (manual SSE frame parsing — no new dependencies).
- `ChatBox` fills a single AI bubble progressively, addressed by a stable id with a synchronous guard so rapid deltas can't append duplicate bubbles. On `done` it swaps in the post-processed reply.
- `ChatMessage` shows a blinking caret while streaming; source chips appear only once the answer completes.

## Testing
- `node --check` on `chat.js` and `api.js` — pass
- ESLint on changed frontend files — clean
- `npm run build` — compiles successfully

## Notes
- No new dependencies added on either side.
- The legacy `appendSourcesIfMissing` / `ensureHighlights` post-processing still runs on the complete answer and is delivered in the `done` event, so the streamed bubble is replaced with the finalized, highlighted version at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ1Yp6kLNtC6B33pyCxrhP)_